### PR TITLE
GG-70: Clean up space in the GitHub pipeline

### DIFF
--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -55,6 +55,20 @@ jobs:
         gg_version: [6, 7]
 
     steps:
+      - name: Clean Up Disk Space
+        run: |
+          # Space usage before cleanup
+          df -h /
+          # Remove unused tool caches
+          rm -rf /usr/lib/jvm
+          rm -rf /usr/local/.ghcup
+          rm -rf /usr/local/lib/android
+          rm -rf /usr/local/share/powershell
+          rm -rf /usr/share/dotnet
+          rm -rf /usr/share/swift
+          # Verify gains
+          df -h /
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -60,12 +60,12 @@ jobs:
           # Space usage before cleanup
           df -h /
           # Remove unused tool caches
-          rm -rf /usr/lib/jvm
-          rm -rf /usr/local/.ghcup
-          rm -rf /usr/local/lib/android
-          rm -rf /usr/local/share/powershell
-          rm -rf /usr/share/dotnet
-          rm -rf /usr/share/swift
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
           # Verify gains
           df -h /
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -11,3 +11,7 @@ docker run --rm -it --sysctl 'kernel.sem=500 1024000 200 4096' gpbackup:test bas
 docker build -t gpbackup:test7x -f Dockerfile --build-arg GGDB_IMAGE=greengagedb/ggdb7_ubuntu:testing .
 docker run --rm -it --sysctl 'kernel.sem=500 1024000 200 4096' gpbackup:test7x bash -c "ssh-keygen -A && /usr/sbin/sshd && bash /home/gpadmin/go/src/github.com/GreengageDB/gpbackup/ci/scripts/run_gpbackup_tests.bash"
 ```
+
+**NOTE**:
+Running all tests requires 11-13 GB, not including the size of the repository
+itself, the Docker image, and the Docker container.


### PR DESCRIPTION
Clean up space in the GitHub pipeline

Currently, GitHub only has about 14 GB of available pipeline space, while
testing requires 11-13 GB, not including the size of the repository itself, the
Docker image, and the Docker container. This means we easily run out of space.
Clean up space at the very beginning of the pipeline.