### PR TITLE
Add check that ggrebalance isn't running

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -47,7 +47,7 @@ func DoSetup() {
 	gplog.Info("gpbackup version = %s", GetVersion())
 
 	utils.CheckGpexpandRunning(utils.BackupPreventedByGpexpandMessage)
-	utils.CheckGgrebalanceRunning(utils.BackupPreventedByGfrebalanceMessage)
+	utils.CheckGgrebalanceRunning(utils.BackupPreventedByGgrebalanceMessage)
 	timestamp := history.CurrentTimestamp()
 	createBackupLockFile(timestamp)
 	initializeConnectionPool(timestamp)

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -47,6 +47,7 @@ func DoSetup() {
 	gplog.Info("gpbackup version = %s", GetVersion())
 
 	utils.CheckGpexpandRunning(utils.BackupPreventedByGpexpandMessage)
+	utils.CheckGgrebalanceRunning(utils.BackupPreventedByGfrebalanceMessage)
 	timestamp := history.CurrentTimestamp()
 	createBackupLockFile(timestamp)
 	initializeConnectionPool(timestamp)

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -55,6 +55,7 @@ func DoSetup() {
 	gplog.Verbose("Restore Command: %s", os.Args)
 
 	utils.CheckGpexpandRunning(utils.RestorePreventedByGpexpandMessage)
+	utils.CheckGgrebalanceRunning(utils.RestorePreventedByGgrebalanceMessage)
 	restoreStartTime = history.CurrentTimestamp()
 
 	CreateConnectionPool("postgres")

--- a/utils/ggdb_tool_sensor.go
+++ b/utils/ggdb_tool_sensor.go
@@ -18,6 +18,36 @@ type GGDBToolSensor struct {
 	postgresConn *dbconn.DBConn
 }
 
+func (sensor *GGDBToolSensor) SetConnection(conn *dbconn.DBConn) {
+	sensor.postgresConn = conn
+}
+
+func (sensor *GGDBToolSensor) SetFs(myfs vfs.Filesystem) {
+	sensor.fs = myfs
+}
+
+type GGDBToolSensorInterface interface {
+	GetMinGgdbVersion() string
+	IsRunning() (bool, error)
+	SetConnection(*dbconn.DBConn)
+	SetFs(vfs.Filesystem)
+}
+
+func checkExtToolRunning(errMsg string, sensor GGDBToolSensorInterface) {
+	postgresConn := dbconn.NewDBConnFromEnvironment("postgres")
+	postgresConn.MustConnect(1)
+	defer postgresConn.Close()
+	if postgresConn.Version.AtLeast(sensor.GetMinGgdbVersion()) {
+		sensor.SetConnection(postgresConn)
+		sensor.SetFs(vfs.OS())
+		isRunning, err := sensor.IsRunning()
+		gplog.FatalOnError(err)
+		if isRunning {
+			gplog.Fatal(errors.New(errMsg), "")
+		}
+	}
+}
+
 func getCoordinatorDataDir(conn *dbconn.DBConn, sensorName string, minGreengageVersion string) (string, error) {
 	err := validateConnection(conn, sensorName, minGreengageVersion)
 	if err != nil {

--- a/utils/ggdb_tool_sensor.go
+++ b/utils/ggdb_tool_sensor.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/GreengageDB/gp-common-go-libs/dbconn"
+	"github.com/GreengageDB/gp-common-go-libs/gplog"
+	"github.com/blang/vfs"
+	"github.com/pkg/errors"
+)
+
+const (
+	CoordinatorDataDirQuery = `select datadir from gp_segment_configuration where content=-1 and role='p'`
+)
+
+type GGDBToolSensor struct {
+	fs           vfs.Filesystem
+	postgresConn *dbconn.DBConn
+}
+
+func getCoordinatorDataDir(conn *dbconn.DBConn, sensorName string, minGreengageVersion string) (string, error) {
+	err := validateConnection(conn, sensorName, minGreengageVersion)
+	if err != nil {
+		gplog.Error(fmt.Sprintf("Error encountered validating db connection: %v", err))
+		return "", err
+	}
+	coordinatorDataDir, err := dbconn.SelectString(conn, CoordinatorDataDirQuery)
+	if err != nil {
+		gplog.Error(fmt.Sprintf("Error encountered retrieving data directory: %v", err))
+		return "", err
+	}
+	return coordinatorDataDir, nil
+}
+
+func validateConnection(conn *dbconn.DBConn, sensorName string, minGreengageVersion string) error {
+	if conn.DBName != "postgres" {
+		return errors.New(sensorName + " sensor requires a connection to the postgres database")
+	}
+	if conn.Version.Before(minGreengageVersion) {
+		return errors.New(sensorName + " sensor requires a connection to Greengage version >= " + minGreengageVersion)
+	}
+	return nil
+}

--- a/utils/ggrebalance_sensor.go
+++ b/utils/ggrebalance_sensor.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	BackupPreventedByGfrebalanceMessage  GgrebalanceFailureMessage = `Greengage rebalance currently in process, please re-run gpbackup when the rebalance has completed`
+	BackupPreventedByGgrebalanceMessage  GgrebalanceFailureMessage = `Greengage rebalance currently in process, please re-run gpbackup when the rebalance has completed`
 	RestorePreventedByGgrebalanceMessage GgrebalanceFailureMessage = `Greengage rebalance currently in process.  Once rebalance is complete, it will be possible to restart gprestore, but please note existing backup sets taken with a different cluster configuration may no longer be compatible with the newly rebalanced cluster configuration`
 
 	GgrebalanceCheckSchemaQuery   = "SELECT COUNT(1) AS rebalance_schema_exists FROM pg_namespace WHERE nspname = 'ggrebalance'"

--- a/utils/ggrebalance_sensor.go
+++ b/utils/ggrebalance_sensor.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	BackupPreventedByGgrebalanceMessage  GgrebalanceFailureMessage = `Greengage rebalance currently in process, please re-run gpbackup when the rebalance has completed`
-	RestorePreventedByGgrebalanceMessage GgrebalanceFailureMessage = `Greengage rebalance currently in process.  Once rebalance is complete, it will be possible to restart gprestore, but please note existing backup sets taken with a different cluster configuration may no longer be compatible with the newly rebalanced cluster configuration`
+	BackupPreventedByGgrebalanceMessage  = `Greengage rebalance currently in process, please re-run gpbackup when the rebalance has completed`
+	RestorePreventedByGgrebalanceMessage = `Greengage rebalance currently in process.  Once rebalance is complete, it will be possible to restart gprestore, but please note existing backup sets taken with a different cluster configuration may no longer be compatible with the newly rebalanced cluster configuration`
 
 	GgrebalanceCheckSchemaQuery    = "SELECT COUNT(1) AS rebalance_schema_exists FROM pg_namespace WHERE nspname = 'ggrebalance'"
 	GgrebalanceGetLatestStateQuery = "SELECT state FROM ggrebalance.rebalance_status WHERE state_category = 'MAIN' ORDER BY updated DESC LIMIT 1"
@@ -25,9 +25,7 @@ type GgrebalanceSensor struct {
 	GGDBToolSensor
 }
 
-type GgrebalanceFailureMessage string
-
-func CheckGgrebalanceRunning(errMsg GgrebalanceFailureMessage) {
+func CheckGgrebalanceRunning(errMsg string) {
 	postgresConn := dbconn.NewDBConnFromEnvironment("postgres")
 	postgresConn.MustConnect(1)
 	defer postgresConn.Close()
@@ -36,7 +34,7 @@ func CheckGgrebalanceRunning(errMsg GgrebalanceFailureMessage) {
 		isGgrebalanceRunning, err := ggrebalanceSensor.IsGgrebalanceRunning()
 		gplog.FatalOnError(err)
 		if isGgrebalanceRunning {
-			gplog.Fatal(errors.New(string(errMsg)), "")
+			gplog.Fatal(errors.New(errMsg), "")
 		}
 	}
 }

--- a/utils/ggrebalance_sensor.go
+++ b/utils/ggrebalance_sensor.go
@@ -28,16 +28,11 @@ func CheckGgrebalanceRunning(errMsg string) {
 	checkExtToolRunning(errMsg, NewGgrebalanceSensorEmpty())
 }
 
-func NewGgrebalanceSensorEmpty() *GgrebalanceSensor {
-	return &GgrebalanceSensor{
-		GGDBToolSensor: GGDBToolSensor{
-			fs:           nil,
-			postgresConn: nil,
-		},
-	}
+func NewGgrebalanceSensorEmpty() GGDBToolSensorInterface {
+	return new(GgrebalanceSensor)
 }
 
-func NewGgrebalanceSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) *GgrebalanceSensor {
+func NewGgrebalanceSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) GGDBToolSensorInterface {
 	sensor := NewGgrebalanceSensorEmpty()
 	sensor.SetConnection(conn)
 	sensor.SetFs(myfs)
@@ -48,7 +43,7 @@ func (sensor GgrebalanceSensor) GetMinGgdbVersion() string {
 	return "7"
 }
 
-func (sensor GgrebalanceSensor) IsRunning() (bool, error) {
+func (sensor *GgrebalanceSensor) IsRunning() (bool, error) {
 	coordinatorDataDir, err := getCoordinatorDataDir(sensor.postgresConn, "ggrebalance", sensor.GetMinGgdbVersion())
 	if err != nil {
 		return false, err

--- a/utils/ggrebalance_sensor.go
+++ b/utils/ggrebalance_sensor.go
@@ -76,12 +76,12 @@ func (sensor GgrebalanceSensor) IsGgrebalanceRunning() (bool, error) {
 		}
 
 		// and check latest state
-		latest_state, err := dbconn.SelectString(sensor.postgresConn, GgrebalanceGetLatesttateQuery)
+		latestState, err := dbconn.SelectString(sensor.postgresConn, GgrebalanceGetLatesttateQuery)
 		if err != nil {
 			gplog.Error(fmt.Sprintf("Error encountered retrieving ggrebalance state status: %v", err))
 			return false, err
 		}
-		if latest_state == "STATE_EXECUTOR_DONE" {
+		if latestState == "STATE_EXECUTOR_DONE" {
 			// latest state is the final one - ggrebalance has completed all operations
 			return false, nil
 		}

--- a/utils/ggrebalance_sensor.go
+++ b/utils/ggrebalance_sensor.go
@@ -8,7 +8,6 @@ import (
 	"github.com/GreengageDB/gp-common-go-libs/dbconn"
 	"github.com/GreengageDB/gp-common-go-libs/gplog"
 	"github.com/blang/vfs"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -26,30 +25,31 @@ type GgrebalanceSensor struct {
 }
 
 func CheckGgrebalanceRunning(errMsg string) {
-	postgresConn := dbconn.NewDBConnFromEnvironment("postgres")
-	postgresConn.MustConnect(1)
-	defer postgresConn.Close()
-	if postgresConn.Version.AtLeast("7") {
-		ggrebalanceSensor := NewGgrebalanceSensor(vfs.OS(), postgresConn)
-		isGgrebalanceRunning, err := ggrebalanceSensor.IsGgrebalanceRunning()
-		gplog.FatalOnError(err)
-		if isGgrebalanceRunning {
-			gplog.Fatal(errors.New(errMsg), "")
-		}
-	}
+	checkExtToolRunning(errMsg, NewGgrebalanceSensorEmpty())
 }
 
-func NewGgrebalanceSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) GgrebalanceSensor {
-	return GgrebalanceSensor{
+func NewGgrebalanceSensorEmpty() *GgrebalanceSensor {
+	return &GgrebalanceSensor{
 		GGDBToolSensor: GGDBToolSensor{
-			fs:           myfs,
-			postgresConn: conn,
+			fs:           nil,
+			postgresConn: nil,
 		},
 	}
 }
 
-func (sensor GgrebalanceSensor) IsGgrebalanceRunning() (bool, error) {
-	coordinatorDataDir, err := getCoordinatorDataDir(sensor.postgresConn, "ggrebalance", "7")
+func NewGgrebalanceSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) *GgrebalanceSensor {
+	sensor := NewGgrebalanceSensorEmpty()
+	sensor.SetConnection(conn)
+	sensor.SetFs(myfs)
+	return sensor
+}
+
+func (sensor GgrebalanceSensor) GetMinGgdbVersion() string {
+	return "7"
+}
+
+func (sensor GgrebalanceSensor) IsRunning() (bool, error) {
+	coordinatorDataDir, err := getCoordinatorDataDir(sensor.postgresConn, "ggrebalance", sensor.GetMinGgdbVersion())
 	if err != nil {
 		return false, err
 	}

--- a/utils/ggrebalance_sensor.go
+++ b/utils/ggrebalance_sensor.go
@@ -1,0 +1,93 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/GreengageDB/gp-common-go-libs/dbconn"
+	"github.com/GreengageDB/gp-common-go-libs/gplog"
+	"github.com/blang/vfs"
+	"github.com/pkg/errors"
+)
+
+const (
+	BackupPreventedByGfrebalanceMessage  GgrebalanceFailureMessage = `Greengage rebalance currently in process, please re-run gpbackup when the rebalance has completed`
+	RestorePreventedByGgrebalanceMessage GgrebalanceFailureMessage = `Greengage rebalance currently in process.  Once rebalance is complete, it will be possible to restart gprestore, but please note existing backup sets taken with a different cluster configuration may no longer be compatible with the newly rebalanced cluster configuration`
+
+	GgrebalanceCheckSchemaQuery   = "SELECT COUNT(1) AS rebalance_schema_exists FROM pg_namespace WHERE nspname = 'ggrebalance'"
+	GgrebalanceGetLatesttateQuery = "SELECT state FROM ggrebalance.rebalance_status WHERE state_category = 'MAIN' ORDER BY updated DESC LIMIT 1"
+
+	GgrebalancePidFilename = "ggrebalance.pid"
+)
+
+type GgrebalanceSensor struct {
+	GGDBToolSensor
+}
+
+type GgrebalanceFailureMessage string
+
+func CheckGgrebalanceRunning(errMsg GgrebalanceFailureMessage) {
+	postgresConn := dbconn.NewDBConnFromEnvironment("postgres")
+	postgresConn.MustConnect(1)
+	defer postgresConn.Close()
+	if postgresConn.Version.AtLeast("7") {
+		ggrebalanceSensor := NewGgrebalanceSensor(vfs.OS(), postgresConn)
+		isGgrebalanceRunning, err := ggrebalanceSensor.IsGgrebalanceRunning()
+		gplog.FatalOnError(err)
+		if isGgrebalanceRunning {
+			gplog.Fatal(errors.New(string(errMsg)), "")
+		}
+	}
+}
+
+func NewGgrebalanceSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) GgrebalanceSensor {
+	return GgrebalanceSensor{
+		GGDBToolSensor: GGDBToolSensor{
+			fs:           myfs,
+			postgresConn: conn,
+		},
+	}
+}
+
+func (sensor GgrebalanceSensor) IsGgrebalanceRunning() (bool, error) {
+	coordinatorDataDir, err := getCoordinatorDataDir(sensor.postgresConn, "ggrebalance", "7")
+	if err != nil {
+		return false, err
+	}
+
+	_, err = sensor.fs.Stat(filepath.Join(coordinatorDataDir, GgrebalancePidFilename))
+	if err == nil {
+		// file exists, so ggrebalance is running
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		// File not present means ggrebalance could be interrupted,
+		// and the cluster was left somewhere in the middle of rebalance.
+		// check ggrebalance schema
+		schemaCheck, err := dbconn.SelectInt(sensor.postgresConn, GgrebalanceCheckSchemaQuery)
+		if err != nil {
+			gplog.Error(fmt.Sprintf("Error encountered retrieving ggrebalance schema status: %v", err))
+			return false, err
+		}
+		if schemaCheck <= 0 {
+			// ggrebalance schema does not exist
+			return false, nil
+		}
+
+		// and check latest state
+		latest_state, err := dbconn.SelectString(sensor.postgresConn, GgrebalanceGetLatesttateQuery)
+		if err != nil {
+			gplog.Error(fmt.Sprintf("Error encountered retrieving ggrebalance state status: %v", err))
+			return false, err
+		}
+		if latest_state == "STATE_EXECUTOR_DONE" {
+			// latest state is the final one - ggrebalance has completed all operations
+			return false, nil
+		}
+
+		return true, nil
+	}
+
+	return false, err
+}

--- a/utils/ggrebalance_sensor.go
+++ b/utils/ggrebalance_sensor.go
@@ -15,8 +15,8 @@ const (
 	BackupPreventedByGgrebalanceMessage  GgrebalanceFailureMessage = `Greengage rebalance currently in process, please re-run gpbackup when the rebalance has completed`
 	RestorePreventedByGgrebalanceMessage GgrebalanceFailureMessage = `Greengage rebalance currently in process.  Once rebalance is complete, it will be possible to restart gprestore, but please note existing backup sets taken with a different cluster configuration may no longer be compatible with the newly rebalanced cluster configuration`
 
-	GgrebalanceCheckSchemaQuery   = "SELECT COUNT(1) AS rebalance_schema_exists FROM pg_namespace WHERE nspname = 'ggrebalance'"
-	GgrebalanceGetLatesttateQuery = "SELECT state FROM ggrebalance.rebalance_status WHERE state_category = 'MAIN' ORDER BY updated DESC LIMIT 1"
+	GgrebalanceCheckSchemaQuery    = "SELECT COUNT(1) AS rebalance_schema_exists FROM pg_namespace WHERE nspname = 'ggrebalance'"
+	GgrebalanceGetLatestStateQuery = "SELECT state FROM ggrebalance.rebalance_status WHERE state_category = 'MAIN' ORDER BY updated DESC LIMIT 1"
 
 	GgrebalancePidFilename = "ggrebalance.pid"
 )
@@ -76,7 +76,7 @@ func (sensor GgrebalanceSensor) IsGgrebalanceRunning() (bool, error) {
 		}
 
 		// and check latest state
-		latestState, err := dbconn.SelectString(sensor.postgresConn, GgrebalanceGetLatesttateQuery)
+		latestState, err := dbconn.SelectString(sensor.postgresConn, GgrebalanceGetLatestStateQuery)
 		if err != nil {
 			gplog.Error(fmt.Sprintf("Error encountered retrieving ggrebalance state status: %v", err))
 			return false, err

--- a/utils/ggrebalance_sensor.go
+++ b/utils/ggrebalance_sensor.go
@@ -39,7 +39,7 @@ func NewGgrebalanceSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) GGDBToolSens
 	return sensor
 }
 
-func (sensor GgrebalanceSensor) GetMinGgdbVersion() string {
+func (sensor *GgrebalanceSensor) GetMinGgdbVersion() string {
 	return "7"
 }
 

--- a/utils/ggrebalance_sensor_test.go
+++ b/utils/ggrebalance_sensor_test.go
@@ -1,0 +1,149 @@
+package utils_test
+
+import (
+	"errors"
+	"path/filepath"
+	"regexp"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/GreengageDB/gp-common-go-libs/testhelper"
+	"github.com/GreengageDB/gpbackup/utils"
+	"github.com/blang/vfs"
+	"github.com/blang/vfs/memfs"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ggrabalance_sensor", func() {
+	const sampleCoordinatorDataDir = "/my_fake_database/demoDataDir-1"
+	var (
+		memoryfs   vfs.Filesystem
+		mddPathRow *sqlmock.Rows
+	)
+
+	BeforeEach(func() {
+		memoryfs = memfs.Create()
+		mddPathRow = sqlmock.NewRows([]string{"datadir"}).AddRow(sampleCoordinatorDataDir)
+		connectionPool.DBName = "postgres"
+
+		if connectionPool.Version.Before("7") {
+			Skip("ggrebalance sensor only runs against GPDB 7+")
+		}
+	})
+	Context("IsGgrebalanceRunning", func() {
+		Describe("happy path", func() {
+			It("senses ggrebalance is not running (no pid file, no schema)", func() {
+				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnRows(mddPathRow)
+				Expect(vfs.MkdirAll(memoryfs, sampleCoordinatorDataDir, 0755)).To(Succeed())
+
+				rebalanceSchemaExistenceRows := sqlmock.NewRows([]string{"rebalance_schema_exists"}).AddRow("0")
+				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceCheckSchemaQuery)).WillReturnRows(rebalanceSchemaExistenceRows)
+
+				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
+				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+			It("senses ggrebalance is not running (no pid file, but schema exists, and latest state is the final one)", func() {
+				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnRows(mddPathRow)
+				Expect(vfs.MkdirAll(memoryfs, sampleCoordinatorDataDir, 0755)).To(Succeed())
+
+				rebalanceSchemaExistenceRows := sqlmock.NewRows([]string{"rebalance_schema_exists"}).AddRow("1")
+				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceCheckSchemaQuery)).WillReturnRows(rebalanceSchemaExistenceRows)
+
+				rebalanceLatestStateRows := sqlmock.NewRows([]string{"state"}).AddRow("STATE_EXECUTOR_DONE")
+				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatesttateQuery)).WillReturnRows(rebalanceLatestStateRows)
+
+				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
+				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeFalse())
+			})
+			It("senses when ggrebalance is running, as determined by existence of the pid file in the coordinator data directory", func() {
+				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnRows(mddPathRow)
+				Expect(vfs.MkdirAll(memoryfs, sampleCoordinatorDataDir, 0755)).To(Succeed())
+				path := filepath.Join(sampleCoordinatorDataDir, utils.GgrebalancePidFilename)
+				Expect(vfs.WriteFile(memoryfs, path, []byte{0}, 0400)).To(Succeed())
+
+				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
+				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+			It("senses ggrebalance is not running (no pid file), but its previous invokation wasn't complete (schema exists, and latest state is not the final one)", func() {
+				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnRows(mddPathRow)
+				Expect(vfs.MkdirAll(memoryfs, sampleCoordinatorDataDir, 0755)).To(Succeed())
+
+				rebalanceSchemaExistenceRows := sqlmock.NewRows([]string{"rebalance_schema_exists"}).AddRow("1")
+				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceCheckSchemaQuery)).WillReturnRows(rebalanceSchemaExistenceRows)
+
+				rebalanceLatestStateRows := sqlmock.NewRows([]string{"state"}).AddRow("STATE_EXECUTOR_STARTED")
+				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatesttateQuery)).WillReturnRows(rebalanceLatestStateRows)
+
+				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
+				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+			It("senses ggrebalance is not running (no pid file), but its previous invokation wasn't complete (schema exists, and no latest state (empty state table))", func() {
+				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnRows(mddPathRow)
+				Expect(vfs.MkdirAll(memoryfs, sampleCoordinatorDataDir, 0755)).To(Succeed())
+
+				rebalanceSchemaExistenceRows := sqlmock.NewRows([]string{"rebalance_schema_exists"}).AddRow("1")
+				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceCheckSchemaQuery)).WillReturnRows(rebalanceSchemaExistenceRows)
+
+				rebalanceLatestStateRows := sqlmock.NewRows([]string{"state"})
+				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatesttateQuery)).WillReturnRows(rebalanceLatestStateRows)
+
+				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
+				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeTrue())
+			})
+		})
+		Describe("sad paths", func() {
+			It("returns an error when MDD query fails", func() {
+				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnError(errors.New("query error"))
+
+				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
+				_, err := ggrebalanceSensor.IsGgrebalanceRunning()
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("query error"))
+			})
+			It("returns an error when Stat for file fails for a reason besides 'does not exist'", func() {
+				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnRows(mddPathRow)
+
+				ggrebalanceSensor := utils.NewGgrebalanceSensor(vfs.Dummy(errors.New("fs error")), connectionPool)
+				_, err := ggrebalanceSensor.IsGgrebalanceRunning()
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("fs error"))
+			})
+			It("returns an error when supplied with a connection to a database != postgres", func() {
+				connectionPool.DBName = "notThePostgresDatabase"
+
+				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
+				_, err := ggrebalanceSensor.IsGgrebalanceRunning()
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("ggrebalance sensor requires a connection to the postgres database"))
+			})
+			It("returns an error when supplied with Greengage version < 7", func() {
+				testhelper.SetDBVersion(connectionPool, "6.1.0")
+
+				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
+				_, err := ggrebalanceSensor.IsGgrebalanceRunning()
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("ggrebalance sensor requires a connection to Greengage version >= 7"))
+			})
+		})
+	})
+})

--- a/utils/ggrebalance_sensor_test.go
+++ b/utils/ggrebalance_sensor_test.go
@@ -54,7 +54,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceCheckSchemaQuery)).WillReturnRows(rebalanceSchemaExistenceRows)
 
 				rebalanceLatestStateRows := sqlmock.NewRows([]string{"state"}).AddRow("STATE_EXECUTOR_DONE")
-				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatesttateQuery)).WillReturnRows(rebalanceLatestStateRows)
+				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatestStateQuery)).WillReturnRows(rebalanceLatestStateRows)
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
 				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
@@ -82,7 +82,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceCheckSchemaQuery)).WillReturnRows(rebalanceSchemaExistenceRows)
 
 				rebalanceLatestStateRows := sqlmock.NewRows([]string{"state"}).AddRow("STATE_EXECUTOR_STARTED")
-				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatesttateQuery)).WillReturnRows(rebalanceLatestStateRows)
+				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatestStateQuery)).WillReturnRows(rebalanceLatestStateRows)
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
 				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
@@ -98,7 +98,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceCheckSchemaQuery)).WillReturnRows(rebalanceSchemaExistenceRows)
 
 				rebalanceLatestStateRows := sqlmock.NewRows([]string{"state"})
-				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatesttateQuery)).WillReturnRows(rebalanceLatestStateRows)
+				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatestStateQuery)).WillReturnRows(rebalanceLatestStateRows)
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
 				result, err := ggrebalanceSensor.IsGgrebalanceRunning()

--- a/utils/ggrebalance_sensor_test.go
+++ b/utils/ggrebalance_sensor_test.go
@@ -41,7 +41,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceCheckSchemaQuery)).WillReturnRows(rebalanceSchemaExistenceRows)
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
-				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
+				result, err := ggrebalanceSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
@@ -57,7 +57,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatestStateQuery)).WillReturnRows(rebalanceLatestStateRows)
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
-				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
+				result, err := ggrebalanceSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
@@ -69,7 +69,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				Expect(vfs.WriteFile(memoryfs, path, []byte{0}, 0400)).To(Succeed())
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
-				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
+				result, err := ggrebalanceSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
@@ -85,7 +85,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatestStateQuery)).WillReturnRows(rebalanceLatestStateRows)
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
-				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
+				result, err := ggrebalanceSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
@@ -101,7 +101,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				mock.ExpectQuery(regexp.QuoteMeta(utils.GgrebalanceGetLatestStateQuery)).WillReturnRows(rebalanceLatestStateRows)
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
-				result, err := ggrebalanceSensor.IsGgrebalanceRunning()
+				result, err := ggrebalanceSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
@@ -112,7 +112,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnError(errors.New("query error"))
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
-				_, err := ggrebalanceSensor.IsGgrebalanceRunning()
+				_, err := ggrebalanceSensor.IsRunning()
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("query error"))
@@ -121,7 +121,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnRows(mddPathRow)
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(vfs.Dummy(errors.New("fs error")), connectionPool)
-				_, err := ggrebalanceSensor.IsGgrebalanceRunning()
+				_, err := ggrebalanceSensor.IsRunning()
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("fs error"))
@@ -130,7 +130,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				connectionPool.DBName = "notThePostgresDatabase"
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
-				_, err := ggrebalanceSensor.IsGgrebalanceRunning()
+				_, err := ggrebalanceSensor.IsRunning()
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("ggrebalance sensor requires a connection to the postgres database"))
@@ -139,7 +139,7 @@ var _ = Describe("ggrabalance_sensor", func() {
 				testhelper.SetDBVersion(connectionPool, "6.1.0")
 
 				ggrebalanceSensor := utils.NewGgrebalanceSensor(memoryfs, connectionPool)
-				_, err := ggrebalanceSensor.IsGgrebalanceRunning()
+				_, err := ggrebalanceSensor.IsRunning()
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("ggrebalance sensor requires a connection to Greengage version >= 7"))

--- a/utils/gpexpand_sensor.go
+++ b/utils/gpexpand_sensor.go
@@ -16,7 +16,6 @@ const (
 
 	RestorePreventedByGpexpandMessage GpexpandFailureMessage = `Greengage expansion currently in process.  Once expansion is complete, it will be possible to restart gprestore, but please note existing backup sets taken with a different cluster configuration may no longer be compatible with the newly expanded cluster configuration`
 
-	CoordinatorDataDirQuery           = `select datadir from gp_segment_configuration where content=-1 and role='p'`
 	GpexpandTemporaryTableStatusQuery = `SELECT status FROM gpexpand.status ORDER BY updated DESC LIMIT 1`
 	GpexpandStatusTableExistsQuery    = `select relname from pg_class JOIN pg_namespace on (pg_class.relnamespace = pg_namespace.oid)  where relname = 'status' and pg_namespace.nspname = 'gpexpand'`
 
@@ -24,8 +23,7 @@ const (
 )
 
 type GpexpandSensor struct {
-	fs           vfs.Filesystem
-	postgresConn *dbconn.DBConn
+	GGDBToolSensor
 }
 
 type GpexpandFailureMessage string
@@ -46,20 +44,16 @@ func CheckGpexpandRunning(errMsg GpexpandFailureMessage) {
 
 func NewGpexpandSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) GpexpandSensor {
 	return GpexpandSensor{
-		fs:           myfs,
-		postgresConn: conn,
+		GGDBToolSensor: GGDBToolSensor{
+			fs:           myfs,
+			postgresConn: conn,
+		},
 	}
 }
 
 func (sensor GpexpandSensor) IsGpexpandRunning() (bool, error) {
-	err := validateConnection(sensor.postgresConn)
+	coordinatorDataDir, err := getCoordinatorDataDir(sensor.postgresConn, "gpexpand", "6")
 	if err != nil {
-		gplog.Error(fmt.Sprintf("Error encountered validating db connection: %v", err))
-		return false, err
-	}
-	coordinatorDataDir, err := dbconn.SelectString(sensor.postgresConn, CoordinatorDataDirQuery)
-	if err != nil {
-		gplog.Error(fmt.Sprintf("Error encountered retrieving data directory: %v", err))
 		return false, err
 	}
 
@@ -103,14 +97,4 @@ func (sensor GpexpandSensor) IsGpexpandRunning() (bool, error) {
 
 	// Stat command returned a "real" error
 	return false, err
-}
-
-func validateConnection(conn *dbconn.DBConn) error {
-	if conn.DBName != "postgres" {
-		return errors.New("gpexpand sensor requires a connection to the postgres database")
-	}
-	if conn.Version.Before("6") {
-		return errors.New("gpexpand sensor requires a connection to Greengage version >= 6")
-	}
-	return nil
 }

--- a/utils/gpexpand_sensor.go
+++ b/utils/gpexpand_sensor.go
@@ -8,7 +8,6 @@ import (
 	"github.com/GreengageDB/gp-common-go-libs/dbconn"
 	"github.com/GreengageDB/gp-common-go-libs/gplog"
 	"github.com/blang/vfs"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -27,30 +26,31 @@ type GpexpandSensor struct {
 }
 
 func CheckGpexpandRunning(errMsg string) {
-	postgresConn := dbconn.NewDBConnFromEnvironment("postgres")
-	postgresConn.MustConnect(1)
-	defer postgresConn.Close()
-	if postgresConn.Version.AtLeast("6") {
-		gpexpandSensor := NewGpexpandSensor(vfs.OS(), postgresConn)
-		isGpexpandRunning, err := gpexpandSensor.IsGpexpandRunning()
-		gplog.FatalOnError(err)
-		if isGpexpandRunning {
-			gplog.Fatal(errors.New(errMsg), "")
-		}
-	}
+	checkExtToolRunning(errMsg, NewGpexpandSensorEmpty())
 }
 
-func NewGpexpandSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) GpexpandSensor {
-	return GpexpandSensor{
+func NewGpexpandSensorEmpty() *GpexpandSensor {
+	return &GpexpandSensor{
 		GGDBToolSensor: GGDBToolSensor{
-			fs:           myfs,
-			postgresConn: conn,
+			fs:           nil,
+			postgresConn: nil,
 		},
 	}
 }
 
-func (sensor GpexpandSensor) IsGpexpandRunning() (bool, error) {
-	coordinatorDataDir, err := getCoordinatorDataDir(sensor.postgresConn, "gpexpand", "6")
+func NewGpexpandSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) *GpexpandSensor {
+	sensor := NewGpexpandSensorEmpty()
+	sensor.SetConnection(conn)
+	sensor.SetFs(myfs)
+	return sensor
+}
+
+func (sensor GpexpandSensor) GetMinGgdbVersion() string {
+	return "6"
+}
+
+func (sensor GpexpandSensor) IsRunning() (bool, error) {
+	coordinatorDataDir, err := getCoordinatorDataDir(sensor.postgresConn, "gpexpand", sensor.GetMinGgdbVersion())
 	if err != nil {
 		return false, err
 	}

--- a/utils/gpexpand_sensor.go
+++ b/utils/gpexpand_sensor.go
@@ -29,16 +29,11 @@ func CheckGpexpandRunning(errMsg string) {
 	checkExtToolRunning(errMsg, NewGpexpandSensorEmpty())
 }
 
-func NewGpexpandSensorEmpty() *GpexpandSensor {
-	return &GpexpandSensor{
-		GGDBToolSensor: GGDBToolSensor{
-			fs:           nil,
-			postgresConn: nil,
-		},
-	}
+func NewGpexpandSensorEmpty() GGDBToolSensorInterface {
+	return new(GpexpandSensor)
 }
 
-func NewGpexpandSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) *GpexpandSensor {
+func NewGpexpandSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) GGDBToolSensorInterface {
 	sensor := NewGpexpandSensorEmpty()
 	sensor.SetConnection(conn)
 	sensor.SetFs(myfs)
@@ -49,7 +44,7 @@ func (sensor GpexpandSensor) GetMinGgdbVersion() string {
 	return "6"
 }
 
-func (sensor GpexpandSensor) IsRunning() (bool, error) {
+func (sensor *GpexpandSensor) IsRunning() (bool, error) {
 	coordinatorDataDir, err := getCoordinatorDataDir(sensor.postgresConn, "gpexpand", sensor.GetMinGgdbVersion())
 	if err != nil {
 		return false, err

--- a/utils/gpexpand_sensor.go
+++ b/utils/gpexpand_sensor.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	BackupPreventedByGpexpandMessage GpexpandFailureMessage = `Greengage expansion currently in process, please re-run gpbackup when the expansion has completed`
+	BackupPreventedByGpexpandMessage = `Greengage expansion currently in process, please re-run gpbackup when the expansion has completed`
 
-	RestorePreventedByGpexpandMessage GpexpandFailureMessage = `Greengage expansion currently in process.  Once expansion is complete, it will be possible to restart gprestore, but please note existing backup sets taken with a different cluster configuration may no longer be compatible with the newly expanded cluster configuration`
+	RestorePreventedByGpexpandMessage = `Greengage expansion currently in process.  Once expansion is complete, it will be possible to restart gprestore, but please note existing backup sets taken with a different cluster configuration may no longer be compatible with the newly expanded cluster configuration`
 
 	GpexpandTemporaryTableStatusQuery = `SELECT status FROM gpexpand.status ORDER BY updated DESC LIMIT 1`
 	GpexpandStatusTableExistsQuery    = `select relname from pg_class JOIN pg_namespace on (pg_class.relnamespace = pg_namespace.oid)  where relname = 'status' and pg_namespace.nspname = 'gpexpand'`
@@ -26,9 +26,7 @@ type GpexpandSensor struct {
 	GGDBToolSensor
 }
 
-type GpexpandFailureMessage string
-
-func CheckGpexpandRunning(errMsg GpexpandFailureMessage) {
+func CheckGpexpandRunning(errMsg string) {
 	postgresConn := dbconn.NewDBConnFromEnvironment("postgres")
 	postgresConn.MustConnect(1)
 	defer postgresConn.Close()
@@ -37,7 +35,7 @@ func CheckGpexpandRunning(errMsg GpexpandFailureMessage) {
 		isGpexpandRunning, err := gpexpandSensor.IsGpexpandRunning()
 		gplog.FatalOnError(err)
 		if isGpexpandRunning {
-			gplog.Fatal(errors.New(string(errMsg)), "")
+			gplog.Fatal(errors.New(errMsg), "")
 		}
 	}
 }

--- a/utils/gpexpand_sensor.go
+++ b/utils/gpexpand_sensor.go
@@ -40,7 +40,7 @@ func NewGpexpandSensor(myfs vfs.Filesystem, conn *dbconn.DBConn) GGDBToolSensorI
 	return sensor
 }
 
-func (sensor GpexpandSensor) GetMinGgdbVersion() string {
+func (sensor *GpexpandSensor) GetMinGgdbVersion() string {
 	return "6"
 }
 

--- a/utils/gpexpand_sensor_test.go
+++ b/utils/gpexpand_sensor_test.go
@@ -42,7 +42,7 @@ var _ = Describe("gpexpand_sensor", func() {
 				Expect(vfs.WriteFile(memoryfs, path, []byte{0}, 0400)).To(Succeed())
 				gpexpandSensor := utils.NewGpexpandSensor(memoryfs, connectionPool)
 
-				result, err := gpexpandSensor.IsGpexpandRunning()
+				result, err := gpexpandSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
@@ -55,7 +55,7 @@ var _ = Describe("gpexpand_sensor", func() {
 				mock.ExpectQuery(utils.GpexpandTemporaryTableStatusQuery).WillReturnRows(hasGpexpandPhase2StatusRow)
 				gpexpandSensor := utils.NewGpexpandSensor(memoryfs, connectionPool)
 
-				result, err := gpexpandSensor.IsGpexpandRunning()
+				result, err := gpexpandSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeTrue())
@@ -67,7 +67,7 @@ var _ = Describe("gpexpand_sensor", func() {
 				mock.ExpectQuery(regexp.QuoteMeta(utils.GpexpandStatusTableExistsQuery)).WillReturnRows(tableDoesNotExistsRow)
 				gpexpandSensor := utils.NewGpexpandSensor(memoryfs, connectionPool)
 
-				result, err := gpexpandSensor.IsGpexpandRunning()
+				result, err := gpexpandSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
@@ -79,7 +79,7 @@ var _ = Describe("gpexpand_sensor", func() {
 				mock.ExpectQuery(utils.GpexpandTemporaryTableStatusQuery).WillReturnRows(finishedGpexpandPhase2StatusRow)
 				gpexpandSensor := utils.NewGpexpandSensor(memoryfs, connectionPool)
 
-				result, err := gpexpandSensor.IsGpexpandRunning()
+				result, err := gpexpandSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
@@ -91,7 +91,7 @@ var _ = Describe("gpexpand_sensor", func() {
 				mock.ExpectQuery(utils.GpexpandTemporaryTableStatusQuery).WillReturnRows(finishedGpexpandPhase2StatusRow)
 				gpexpandSensor := utils.NewGpexpandSensor(memoryfs, connectionPool)
 
-				result, err := gpexpandSensor.IsGpexpandRunning()
+				result, err := gpexpandSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
@@ -103,7 +103,7 @@ var _ = Describe("gpexpand_sensor", func() {
 				mock.ExpectQuery(utils.GpexpandTemporaryTableStatusQuery).WillReturnRows(finishedGpexpandPhase2StatusRow)
 				gpexpandSensor := utils.NewGpexpandSensor(memoryfs, connectionPool)
 
-				result, err := gpexpandSensor.IsGpexpandRunning()
+				result, err := gpexpandSensor.IsRunning()
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeFalse())
@@ -114,7 +114,7 @@ var _ = Describe("gpexpand_sensor", func() {
 				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnError(errors.New("query error"))
 				gpexpandSensor := utils.NewGpexpandSensor(memoryfs, connectionPool)
 
-				_, err := gpexpandSensor.IsGpexpandRunning()
+				_, err := gpexpandSensor.IsRunning()
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("query error"))
@@ -123,7 +123,7 @@ var _ = Describe("gpexpand_sensor", func() {
 				mock.ExpectQuery(utils.CoordinatorDataDirQuery).WillReturnRows(mddPathRow)
 				gpexpandSensor := utils.NewGpexpandSensor(vfs.Dummy(errors.New("fs error")), connectionPool)
 
-				_, err := gpexpandSensor.IsGpexpandRunning()
+				_, err := gpexpandSensor.IsRunning()
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("fs error"))
@@ -132,7 +132,7 @@ var _ = Describe("gpexpand_sensor", func() {
 				connectionPool.DBName = "notThePostgresDatabase"
 				gpexpandSensor := utils.NewGpexpandSensor(memoryfs, connectionPool)
 
-				_, err := gpexpandSensor.IsGpexpandRunning()
+				_, err := gpexpandSensor.IsRunning()
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("gpexpand sensor requires a connection to the postgres database"))
@@ -141,7 +141,7 @@ var _ = Describe("gpexpand_sensor", func() {
 				testhelper.SetDBVersion(connectionPool, "5.3.0")
 				gpexpandSensor := utils.NewGpexpandSensor(memoryfs, connectionPool)
 
-				_, err := gpexpandSensor.IsGpexpandRunning()
+				_, err := gpexpandSensor.IsRunning()
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("gpexpand sensor requires a connection to Greengage version >= 6"))


### PR DESCRIPTION
Add check that ggrebalance isn't running

This patch adds a capability to check if the 'ggrebalance' tool is currently
running. In such a case, 'gpbackup'/'gprestore' halt their execution.

The check is similar to the already existing check for 'gpexpand'. The existing
'gpexpand' sensor related code was refactored in order to separate the common
part for both tool sensors (now it resides in 'utils/ggdb_tool_sensor.go').