### PR TITLE
CI-5904 Add release workflow

### DIFF
--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
 
   build_and_unit_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
       with:
@@ -48,7 +48,7 @@ jobs:
 
   build_and_test:
     name: Regression tests on Greengage ${{ matrix.gg_version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+# .github/workflows/greengage-release.yml
+name: GreengageDB gpbackup Release
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  upload-to-release:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - target_os: ubuntu
+          target_os_version: 22.04
+          extensions:  deb ddeb
+        - target_os: ubuntu
+          target_os_version: 24.04
+          extensions:  deb ddeb
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Upload packages to release
+        uses: greengagedb/greengage-ci/.github/actions/upload-pkgs-to-release@v45
+        with:
+          workflow_for_waiting: Build deb
+          target_os:            ${{ matrix.target_os }}
+          target_os_version:    ${{ matrix.target_os_version }}
+          extensions:           ${{ matrix.extensions }}
+          artifact_prefix:      gpbackup-deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         - target_os: ubuntu
           target_os_version: 24.04
           extensions:  deb ddeb
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       actions: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# .github/workflows/greengage-release.yml
+# .github/workflows/release.yml
 name: GreengageDB gpbackup Release
 
 on:


### PR DESCRIPTION
### CI-5904 Add release workflow (#19)

Release workflow added to attach deb packages to releases.

Tests: https://github.com/uaqq/gpbackup/actions/runs/28462493150

Task: CI-5904