### PR TITLE
GG-630: Implement general utility functions for ggcheckmigrate

### DIFF
--- a/checkmigrate/checkmigrate.go
+++ b/checkmigrate/checkmigrate.go
@@ -17,6 +17,7 @@ func DoInit(cmd *cobra.Command) {
 	CleanupGroup = &sync.WaitGroup{}
 	CleanupGroup.Add(1)
 	gplog.InitializeLogging("ggcheckmigrate", "")
+	SetCmdFlags(cmd.Flags())
 	utils.InitializeSignalHandler(DoCleanup, "checkmigrate process", &wasTerminated)
 }
 

--- a/checkmigrate/checkmigrate.go
+++ b/checkmigrate/checkmigrate.go
@@ -22,10 +22,8 @@ func DoInit(cmd *cobra.Command) {
 	utils.InitializeSignalHandler(DoCleanup, "checkmigrate process", &wasTerminated)
 }
 
-/*
- * This function handles argument parsing and validation, e.g. checking that a passed filename exists.
- * It should only validate; initialization with any sort of side effects should go in DoInit or DoSetup.
- */
+// This function handles argument parsing and validation, e.g. checking that a passed filename exists.
+// It should only validate; initialization with any sort of side effects should go in DoInit or DoSetup.
 func DoFlagValidation(cmd *cobra.Command) {
 	ValidateFlagCombinations(cmd.Flags())
 }
@@ -74,12 +72,10 @@ func DoTeardown() {
 		checkmigrateFailed = true
 	}
 	if wasTerminated.Load() {
-		/*
-		 * Don't print an error if the checkmigrate was canceled, as the signal handler
-		 * will take care of cleanup and return codes.  Just wait until the signal
-		 * handler's DoCleanup completes so the main goroutine doesn't exit while
-		 * cleanup is still in progress.
-		 */
+		// Don't print an error if the checkmigrate was canceled, as the signal handler
+		// will take care of cleanup and return codes.  Just wait until the signal
+		// handler's DoCleanup completes so the main goroutine doesn't exit while
+		// cleanup is still in progress.
 		CleanupGroup.Wait()
 		checkmigrateFailed = true
 		return

--- a/checkmigrate/checkmigrate.go
+++ b/checkmigrate/checkmigrate.go
@@ -16,6 +16,7 @@ import (
 func DoInit(cmd *cobra.Command) {
 	CleanupGroup = &sync.WaitGroup{}
 	CleanupGroup.Add(1)
+	cleanupOnce = sync.Once{}
 	gplog.InitializeLogging("ggcheckmigrate", "")
 	SetCmdFlags(cmd.Flags())
 	utils.InitializeSignalHandler(DoCleanup, "checkmigrate process", &wasTerminated)
@@ -56,10 +57,10 @@ func DoTeardown() {
 
 	errStr := ""
 	if err := recover(); err != nil {
-		// Check if gplog.Fatal did not cause the panic
-		if gplog.GetErrorCode() != 2 {
+		errorCode := gplog.GetErrorCode()
+		if errorCode < 2 || errorCode > 5 {
 			gplog.Error(fmt.Sprintf("%v: %s", err, debug.Stack()))
-			gplog.SetErrorCode(2)
+			gplog.SetErrorCode(5)
 		} else {
 			errStr = fmt.Sprintf("%+v", err)
 		}
@@ -82,20 +83,22 @@ func DoTeardown() {
 }
 
 func DoCleanup(checkmigrateFailed bool) {
-	defer func() {
-		if err := recover(); err != nil {
-			gplog.Warn("Encountered error during cleanup: %+v", err)
+	cleanupOnce.Do(func() {
+		defer func() {
+			if err := recover(); err != nil {
+				gplog.Warn("Encountered error during cleanup: %+v", err)
+			}
+			gplog.Info("Cleanup complete")
+			CleanupGroup.Done()
+		}()
+
+		gplog.Info("Beginning cleanup")
+
+		if sourceConnectionPool != nil {
+			sourceConnectionPool.Close()
 		}
-		gplog.Info("Cleanup complete")
-		CleanupGroup.Done()
-	}()
-
-	gplog.Info("Beginning cleanup")
-
-	if sourceConnectionPool != nil {
-		sourceConnectionPool.Close()
-	}
-	if targetConnectionPool != nil {
-		targetConnectionPool.Close()
-	}
+		if targetConnectionPool != nil {
+			targetConnectionPool.Close()
+		}
+	})
 }

--- a/checkmigrate/checkmigrate.go
+++ b/checkmigrate/checkmigrate.go
@@ -16,7 +16,7 @@ import (
 func DoInit(cmd *cobra.Command) {
 	CleanupGroup = &sync.WaitGroup{}
 	CleanupGroup.Add(1)
-	gplog.InitializeLogging("gprestore", "")
+	gplog.InitializeLogging("ggcheckmigrate", "")
 	utils.InitializeSignalHandler(DoCleanup, "checkmigrate process", &wasTerminated)
 }
 
@@ -66,7 +66,7 @@ func DoTeardown() {
 	}
 	if wasTerminated.Load() {
 		/*
-		 * Don't print an error if the restore was canceled, as the signal handler
+		 * Don't print an error if the checkmigrate was canceled, as the signal handler
 		 * will take care of cleanup and return codes.  Just wait until the signal
 		 * handler's DoCleanup completes so the main goroutine doesn't exit while
 		 * cleanup is still in progress.

--- a/checkmigrate/checkmigrate.go
+++ b/checkmigrate/checkmigrate.go
@@ -1,15 +1,34 @@
 package checkmigrate
 
 import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"sync"
+
+	"github.com/GreengageDB/gp-common-go-libs/gplog"
+	"github.com/GreengageDB/gpbackup/utils"
+
 	"github.com/spf13/cobra"
 )
 
+// This function handles setup that can be done before parsing flags.
 func DoInit(cmd *cobra.Command) {
-
+	CleanupGroup = &sync.WaitGroup{}
+	CleanupGroup.Add(1)
+	gplog.InitializeLogging("gprestore", "")
+	utils.InitializeSignalHandler(DoCleanup, "checkmigrate process", &wasTerminated)
 }
 
+// This function handles setup that must be done after parsing flags.
 func DoSetup() {
+	// TODO: This one requires parsed flags
+	//SetLoggerVerbosity()
+	gplog.Verbose("CheckMigrate Command: %s", os.Args)
+	gplog.Info("checkmigrate version = %s", GetVersion())
 
+	// TODO: Use flags in CreateConnectionPool
+	//CreateConnectionPool()
 }
 
 func DoCheckMigrate() {
@@ -17,4 +36,65 @@ func DoCheckMigrate() {
 }
 
 func DoTeardown() {
+	checkmigrateFailed := false
+	defer func() {
+		// If the checkmigrate was terminated, the signal handler will handle cleanup
+		if wasTerminated.Load() {
+			CleanupGroup.Wait()
+		} else {
+			DoCleanup(checkmigrateFailed)
+		}
+
+		errorCode := gplog.GetErrorCode()
+		if errorCode == 0 {
+			gplog.Info("CheckMigrate completed successfully")
+		}
+		os.Exit(errorCode)
+
+	}()
+
+	errStr := ""
+	if err := recover(); err != nil {
+		// Check if gplog.Fatal did not cause the panic
+		if gplog.GetErrorCode() != 2 {
+			gplog.Error(fmt.Sprintf("%v: %s", err, debug.Stack()))
+			gplog.SetErrorCode(2)
+		} else {
+			errStr = fmt.Sprintf("%+v", err)
+		}
+		checkmigrateFailed = true
+	}
+	if wasTerminated.Load() {
+		/*
+		 * Don't print an error if the restore was canceled, as the signal handler
+		 * will take care of cleanup and return codes.  Just wait until the signal
+		 * handler's DoCleanup completes so the main goroutine doesn't exit while
+		 * cleanup is still in progress.
+		 */
+		CleanupGroup.Wait()
+		checkmigrateFailed = true
+		return
+	}
+	if errStr != "" {
+		fmt.Println(errStr)
+	}
+}
+
+func DoCleanup(checkmigrateFailed bool) {
+	defer func() {
+		if err := recover(); err != nil {
+			gplog.Warn("Encountered error during cleanup: %+v", err)
+		}
+		gplog.Info("Cleanup complete")
+		CleanupGroup.Done()
+	}()
+
+	gplog.Info("Beginning cleanup")
+
+	if sourceConnectionPool != nil {
+		sourceConnectionPool.Close()
+	}
+	if targetConnectionPool != nil {
+		targetConnectionPool.Close()
+	}
 }

--- a/checkmigrate/checkmigrate_internal_test.go
+++ b/checkmigrate/checkmigrate_internal_test.go
@@ -1,0 +1,29 @@
+package checkmigrate
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/GreengageDB/gp-common-go-libs/gplog"
+)
+
+func TestDoCleanupRunsOnce(t *testing.T) {
+	gplog.InitializeLogging("ggcheckmigrate-test", t.TempDir())
+	CleanupGroup = &sync.WaitGroup{}
+	CleanupGroup.Add(1)
+	cleanupOnce = sync.Once{}
+	sourceConnectionPool = nil
+	targetConnectionPool = nil
+
+	var callers sync.WaitGroup
+	callers.Add(2)
+	for callerIndex := 0; callerIndex < 2; callerIndex++ {
+		go func() {
+			defer callers.Done()
+			DoCleanup(false)
+		}()
+	}
+
+	callers.Wait()
+	CleanupGroup.Wait()
+}

--- a/checkmigrate/global_variables.go
+++ b/checkmigrate/global_variables.go
@@ -1,12 +1,41 @@
 package checkmigrate
 
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/GreengageDB/gp-common-go-libs/dbconn"
+	"github.com/GreengageDB/gpbackup/options"
+
+	"github.com/spf13/pflag"
+)
+
 /*
  * Non-flag variables
  */
 var (
-	version              	string
+	sourceConnectionPool		*dbconn.DBConn
+	targetConnectionPool		*dbconn.DBConn
+	version             		string
+	wasTerminated       		atomic.Bool
+
+	/*
+	 * Used for synchronizing DoCleanup.  In DoInit() we increment the group
+	 * and then wait for at least one DoCleanup to finish, either in DoTeardown
+	 * or the signal handler.
+	 */
+	CleanupGroup *sync.WaitGroup
 )
+
+/*
+ * Command-line flags
+ */
+var cmdFlags *pflag.FlagSet
 
 func GetVersion() string {
 	return version
+}
+
+func MustGetFlagBool(flagName string) bool {
+	return options.MustGetFlagBool(cmdFlags, flagName)
 }

--- a/checkmigrate/global_variables.go
+++ b/checkmigrate/global_variables.go
@@ -18,6 +18,7 @@ var (
 	targetConnectionPool *dbconn.DBConn
 	version              string
 	wasTerminated        atomic.Bool
+	cleanupOnce          sync.Once
 
 	/*
 	 * Used for synchronizing DoCleanup.  In DoInit() we increment the group

--- a/checkmigrate/global_variables.go
+++ b/checkmigrate/global_variables.go
@@ -14,10 +14,10 @@ import (
  * Non-flag variables
  */
 var (
-	sourceConnectionPool		*dbconn.DBConn
-	targetConnectionPool		*dbconn.DBConn
-	version             		string
-	wasTerminated       		atomic.Bool
+	sourceConnectionPool *dbconn.DBConn
+	targetConnectionPool *dbconn.DBConn
+	version              string
+	wasTerminated        atomic.Bool
 
 	/*
 	 * Used for synchronizing DoCleanup.  In DoInit() we increment the group
@@ -31,6 +31,10 @@ var (
  * Command-line flags
  */
 var cmdFlags *pflag.FlagSet
+
+func SetCmdFlags(flagSet *pflag.FlagSet) {
+	cmdFlags = flagSet
+}
 
 func GetVersion() string {
 	return version

--- a/checkmigrate/global_variables.go
+++ b/checkmigrate/global_variables.go
@@ -10,9 +10,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-/*
- * Non-flag variables
- */
+// Non-flag variables
 var (
 	sourceConnectionPool *dbconn.DBConn
 	targetConnectionPool *dbconn.DBConn
@@ -20,22 +18,16 @@ var (
 	wasTerminated        atomic.Bool
 	cleanupOnce          sync.Once
 
-	/*
-	 * Used for synchronizing DoCleanup.  In DoInit() we increment the group
-	 * and then wait for at least one DoCleanup to finish, either in DoTeardown
-	 * or the signal handler.
-	 */
+	// Used for synchronizing DoCleanup.  In DoInit() we increment the group
+	// and then wait for at least one DoCleanup to finish, either in DoTeardown
+	// or the signal handler.
 	CleanupGroup *sync.WaitGroup
 )
 
-/*
- * Command-line flags
- */
+// Command-line flags
 var cmdFlags *pflag.FlagSet
 
-/*
- * Setter functions
- */
+// Setter functions
 func SetCmdFlags(flagSet *pflag.FlagSet) {
 	cmdFlags = flagSet
 	options.SetCheckMigrateFlagDefaults(cmdFlags)
@@ -45,16 +37,12 @@ func SetVersion(v string) {
 	version = v
 }
 
-/*
- * Getter functions
- */
+// Getter functions
 func GetVersion() string {
 	return version
 }
 
-/*
- * Util functions to enable ease of access to global flag values
- */
+// Util functions to enable ease of access to global flag values
 func FlagChanged(flagName string) bool {
 	return cmdFlags.Changed(flagName)
 }

--- a/checkmigrate/wrappers.go
+++ b/checkmigrate/wrappers.go
@@ -38,18 +38,28 @@ func SetLoggerVerbosity() {
  *
  * Also, there seem to be no Conn() function to pass a password to it,
  * Might need to be written.
- */ 
+ */
 func CreateConnectionPool() {
 	sourceConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/tmp", 6000)
-	sourceConnectionPool.MustConnect(1);
+	err := sourceConnectionPool.Connect(1)
+	if err != nil {
+		gplog.SetErrorCode(5)
+		panic(err)
+	}
 	if !sourceConnectionPool.Version.Is("6") {
-		gplog.Fatal(errors.Errorf(`Source GPDB version %s is not supported. Utility is used only on GPDB %s as source.`, sourceConnectionPool.Version.VersionString, "6"), "")
+		gplog.SetErrorCode(2)
+		panic(errors.Errorf(`Source GPDB version %s is not supported. Utility is used only on GPDB %s as source.`, sourceConnectionPool.Version.VersionString, "6"))
 	}
 
 	// TODO: Handle this, only if target-host flag is defined
 	targetConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/tmp", 7000)
-	targetConnectionPool.MustConnect(1);
+	err = targetConnectionPool.Connect(1)
+	if err != nil {
+		gplog.SetErrorCode(5)
+		panic(err)
+	}
 	if !targetConnectionPool.Version.Is("7") {
-		gplog.Fatal(errors.Errorf(`Target GPDB version %s is not supported. Utility is used only on GPDB %s as target.`, targetConnectionPool.Version.VersionString, "7"), "")
+		gplog.SetErrorCode(3)
+		panic(errors.Errorf(`Target GPDB version %s is not supported. Utility is used only on GPDB %s as target.`, targetConnectionPool.Version.VersionString, "7"))
 	}
 }

--- a/checkmigrate/wrappers.go
+++ b/checkmigrate/wrappers.go
@@ -8,16 +8,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-/*
- * This file contains wrapper functions that group together functions relating
- * to querying and printing metadata, so that the logic for each object type
- * can all be in one place and backup.go can serve as a high-level look at the
- * overall backup flow.
- */
+// This file contains wrapper functions that group together functions relating
+// to querying and printing metadata, so that the logic for each object type
+// can all be in one place and backup.go can serve as a high-level look at the
+// overall backup flow.
 
-/*
- * Setup and validation wrapper functions
- */
+// Setup and validation wrapper functions
 
 func SetLoggerVerbosity() {
 	gplog.SetLogFileVerbosity(gplog.LOGINFO)
@@ -33,12 +29,10 @@ func SetLoggerVerbosity() {
 	}
 }
 
-/*
- * TODO: Handle source and target flags here and pass them to NewDBConn
- *
- * Also, there seem to be no Conn() function to pass a password to it,
- * Might need to be written.
- */
+// TODO: Handle source and target flags here and pass them to NewDBConn
+//
+// Also, there seem to be no Conn() function to pass a password to it,
+// Might need to be written.
 func CreateConnectionPool() {
 	sourceConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/tmp", 6000)
 	err := sourceConnectionPool.Connect(1)

--- a/checkmigrate/wrappers.go
+++ b/checkmigrate/wrappers.go
@@ -1,0 +1,53 @@
+package checkmigrate
+
+import (
+	"github.com/GreengageDB/gp-common-go-libs/dbconn"
+	"github.com/GreengageDB/gp-common-go-libs/gplog"
+	"github.com/GreengageDB/gpbackup/options"
+
+	"github.com/pkg/errors"
+)
+
+/*
+ * This file contains wrapper functions that group together functions relating
+ * to querying and printing metadata, so that the logic for each object type
+ * can all be in one place and backup.go can serve as a high-level look at the
+ * overall backup flow.
+ */
+
+/*
+ * Setup and validation wrapper functions
+ */
+
+func SetLoggerVerbosity() {
+	gplog.SetLogFileVerbosity(gplog.LOGINFO)
+	if MustGetFlagBool(options.QUIET) {
+		gplog.SetVerbosity(gplog.LOGERROR)
+		gplog.SetLogFileVerbosity(gplog.LOGERROR)
+	} else if MustGetFlagBool(options.DEBUG) {
+		gplog.SetVerbosity(gplog.LOGDEBUG)
+		gplog.SetLogFileVerbosity(gplog.LOGDEBUG)
+	} else if MustGetFlagBool(options.VERBOSE) {
+		gplog.SetVerbosity(gplog.LOGVERBOSE)
+		gplog.SetLogFileVerbosity(gplog.LOGVERBOSE)
+	}
+}
+
+/*
+ * TODO: Handle source and target flags here and pass them to NewDBConn
+ *
+ * Also, there seem to be no Conn() function to pass a password to it,
+ * Might need to be written.
+ */ 
+func CreateConnectionPool() {
+	sourceConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/var/run/sock1", 5432)
+	if !sourceConnectionPool.Version.Is("6") {
+		gplog.Fatal(errors.Errorf(`Source GPDB version %s is not supported. Utility is used only on GPDB %s as source.`, sourceConnectionPool.Version.VersionString, "6"), "")
+	}
+
+	// TODO: Handle this, only if target-host flag is defined
+	targetConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/var/cun/sock2", 5432)
+	if !targetConnectionPool.Version.Is("7") {
+		gplog.Fatal(errors.Errorf(`Target GPDB version %s is not supported. Utility is used only on GPDB %s as target.`, targetConnectionPool.Version.VersionString, "7"), "")
+	}
+}

--- a/checkmigrate/wrappers.go
+++ b/checkmigrate/wrappers.go
@@ -40,13 +40,15 @@ func SetLoggerVerbosity() {
  * Might need to be written.
  */ 
 func CreateConnectionPool() {
-	sourceConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/var/run/sock1", 5432)
+	sourceConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/tmp", 6000)
+	sourceConnectionPool.MustConnect(1);
 	if !sourceConnectionPool.Version.Is("6") {
 		gplog.Fatal(errors.Errorf(`Source GPDB version %s is not supported. Utility is used only on GPDB %s as source.`, sourceConnectionPool.Version.VersionString, "6"), "")
 	}
 
 	// TODO: Handle this, only if target-host flag is defined
-	targetConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/var/cun/sock2", 5432)
+	targetConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/tmp", 7000)
+	targetConnectionPool.MustConnect(1);
 	if !targetConnectionPool.Version.Is("7") {
 		gplog.Fatal(errors.Errorf(`Target GPDB version %s is not supported. Utility is used only on GPDB %s as target.`, targetConnectionPool.Version.VersionString, "7"), "")
 	}

--- a/ggcheckmigrate.go
+++ b/ggcheckmigrate.go
@@ -5,8 +5,8 @@ package main
 import (
 	"os"
 
-	"github.com/GreengageDB/gpbackup/options"
 	. "github.com/GreengageDB/gpbackup/checkmigrate"
+	"github.com/GreengageDB/gpbackup/options"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
What is it?
In this PR basic commands for ggcheckmigrate are added (DoInit(), DoSetup(),
DoTeardown()). Yet, they lack flag handling which should be added in next PRs.

Tests?
No tests are needed, at least for a time until ggcheckmigrate is not ready for
end-to-end.

Ticket: GG-630

Co-authored-by: Vladimir Sarmin \<v.sarmin@arenadata.io\>