### PR TITLE
GG-651: Use options inside CreateConnectionPool()

### DIFF
--- a/checkmigrate/checkmigrate.go
+++ b/checkmigrate/checkmigrate.go
@@ -34,8 +34,7 @@ func DoSetup() {
 	gplog.Verbose("CheckMigrate Command: %s", os.Args)
 	gplog.Info("ggcheckmigrate version = %s", GetVersion())
 
-	// TODO: Use flags in CreateConnectionPool
-	//CreateConnectionPool()
+	CreateConnectionPool()
 }
 
 func DoCheckMigrate() {

--- a/checkmigrate/global_variables.go
+++ b/checkmigrate/global_variables.go
@@ -18,7 +18,7 @@ var (
 	wasTerminated        atomic.Bool
 	cleanupOnce          sync.Once
 
-	scrapeDbNames		 bool
+	scrapeDbNames bool
 
 	// Used for mocking purposes
 	createDBConn = dbconn.NewDBConn

--- a/checkmigrate/global_variables.go
+++ b/checkmigrate/global_variables.go
@@ -20,6 +20,9 @@ var (
 
 	scrapeDbNames		 bool
 
+	// Used for mocking purposes
+	createDBConn = dbconn.NewDBConn
+
 	// Used for synchronizing DoCleanup.  In DoInit() we increment the group
 	// and then wait for at least one DoCleanup to finish, either in DoTeardown
 	// or the signal handler.
@@ -39,9 +42,32 @@ func SetVersion(v string) {
 	version = v
 }
 
+func SetCreateDBConn(f func(dbName, username, host string, port int) *dbconn.DBConn) {
+	createDBConn = f
+}
+
 // Getter functions
 func GetVersion() string {
 	return version
+}
+
+func GetSourceConnectionPool() *dbconn.DBConn {
+	return sourceConnectionPool
+}
+
+func GetTargetConnectionPool() *dbconn.DBConn {
+	return targetConnectionPool
+}
+
+func GetScrapeDbNames() bool {
+	return scrapeDbNames
+}
+
+// ResetGlobalState() clears the global variables before each test
+func ResetGlobalState() {
+	sourceConnectionPool = nil
+	targetConnectionPool = nil
+	scrapeDbNames = false
 }
 
 // Util functions to enable ease of access to global flag values

--- a/checkmigrate/global_variables.go
+++ b/checkmigrate/global_variables.go
@@ -18,6 +18,8 @@ var (
 	wasTerminated        atomic.Bool
 	cleanupOnce          sync.Once
 
+	scrapeDbNames		 bool
+
 	// Used for synchronizing DoCleanup.  In DoInit() we increment the group
 	// and then wait for at least one DoCleanup to finish, either in DoTeardown
 	// or the signal handler.

--- a/checkmigrate/validate.go
+++ b/checkmigrate/validate.go
@@ -1,11 +1,16 @@
 package checkmigrate
 
 import (
+	"github.com/GreengageDB/gp-common-go-libs/gplog"
 	"github.com/GreengageDB/gpbackup/options"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
 
 func ValidateFlagCombinations(flags *pflag.FlagSet) {
 	options.CheckExclusiveFlags(flags, options.DEBUG, options.QUIET, options.VERBOSE)
+	if flags.Changed(options.TARGET_HOST) != flags.Changed(options.TARGET_PORT) {
+		gplog.Fatal(errors.New("Both -H and -P options need to be provided to check target cluster"), "")
+	}
 }

--- a/checkmigrate/validate.go
+++ b/checkmigrate/validate.go
@@ -21,7 +21,7 @@ func ValidateFlagCombinations(flags *pflag.FlagSet) {
 	hasTargetHost := flags.Changed(options.TARGET_HOST)
 	hasTargetPort := flags.Changed(options.TARGET_PORT)
 	hasTargetUser := flags.Changed(options.TARGET_USER)
-	if hasTargetHost != hasTargetPort || hasTargetUser && !hasTargetHost {
+	if hasTargetHost != hasTargetPort || (hasTargetUser && !hasTargetHost) {
 		gplog.Fatal(errors.New("Both -H and -P options need to be provided to check target cluster"), "")
 	}
 	if hasTargetHost {

--- a/checkmigrate/validate.go
+++ b/checkmigrate/validate.go
@@ -10,7 +10,28 @@ import (
 
 func ValidateFlagCombinations(flags *pflag.FlagSet) {
 	options.CheckExclusiveFlags(flags, options.DEBUG, options.QUIET, options.VERBOSE)
-	if flags.Changed(options.TARGET_HOST) != flags.Changed(options.TARGET_PORT) {
+
+	if flags.Changed(options.SOURCE_PORT) {
+		sourcePort := options.MustGetFlagInt(flags, options.SOURCE_PORT)
+		if sourcePort < 1 || sourcePort > 65535 {
+			gplog.Fatal(errors.New("The source port must be between 1 and 65535"), "")
+		}
+	}
+
+	hasTargetHost := flags.Changed(options.TARGET_HOST)
+	hasTargetPort := flags.Changed(options.TARGET_PORT)
+	hasTargetUser := flags.Changed(options.TARGET_USER)
+	if hasTargetHost != hasTargetPort || hasTargetUser && !hasTargetHost {
 		gplog.Fatal(errors.New("Both -H and -P options need to be provided to check target cluster"), "")
+	}
+	if hasTargetHost {
+		targetHost := options.MustGetFlagString(flags, options.TARGET_HOST)
+		targetPort := options.MustGetFlagInt(flags, options.TARGET_PORT)
+		if targetHost == "" {
+			gplog.Fatal(errors.New("The target host must not be empty"), "")
+		}
+		if targetPort < 1 || targetPort > 65535 {
+			gplog.Fatal(errors.New("The target port must be between 1 and 65535"), "")
+		}
 	}
 }

--- a/checkmigrate/validate_test.go
+++ b/checkmigrate/validate_test.go
@@ -36,9 +36,18 @@ var _ = Describe("checkmigrate/validate tests", func() {
 				}
 			},
 
+			Entry("minimum source port", "--source-port 1", true),
+			Entry("maximum source port", "--source-port 65535", true),
+			Entry("zero source port", "--source-port 0", false),
+			Entry("negative source port", "--source-port -1", false),
+			Entry("source port above maximum", "--source-port 65536", false),
 			Entry("target host and port", "--target-host localhost --target-port 7000", true),
 			Entry("target host without port", "--target-host localhost", false),
 			Entry("target port without host", "--target-port 7000", false),
+			Entry("target user without host and port", "--target-user gpadmin", false),
+			Entry("zero target port", "--target-host localhost --target-port 0", false),
+			Entry("negative target port", "--target-host localhost --target-port -1", false),
+			Entry("target port above maximum", "--target-host localhost --target-port 65536", false),
 			Entry("debug flag", "--debug", true),
 			Entry("quiet flag", "--quiet", true),
 			Entry("verbose flag", "--verbose", true),

--- a/checkmigrate/validate_test.go
+++ b/checkmigrate/validate_test.go
@@ -45,6 +45,8 @@ var _ = Describe("checkmigrate/validate tests", func() {
 			Entry("target host without port", "--target-host localhost", false),
 			Entry("target port without host", "--target-port 7000", false),
 			Entry("target user without host and port", "--target-user gpadmin", false),
+			Entry("target user with host but without port", "--target-user gpadmin --target-host localhost", false),
+			Entry("target user without host but with port", "--target-user gpadmin --target-port 7000", false),
 			Entry("zero target port", "--target-host localhost --target-port 0", false),
 			Entry("negative target port", "--target-host localhost --target-port -1", false),
 			Entry("target port above maximum", "--target-host localhost --target-port 65536", false),

--- a/checkmigrate/validate_test.go
+++ b/checkmigrate/validate_test.go
@@ -36,12 +36,9 @@ var _ = Describe("checkmigrate/validate tests", func() {
 				}
 			},
 
-			Entry("source no-password long flag", "--source-no-password", true),
-			Entry("source no-password short flag", "-w", true),
-			Entry("target no-password long flag", "--target-no-password", true),
-			Entry("target no-password short flag", "-W", true),
-			Entry("both no-password long flags", "--source-no-password --target-no-password", true),
-			Entry("both no-password short flags", "-w -W", true),
+			Entry("target host and port", "--target-host localhost --target-port 7000", true),
+			Entry("target host without port", "--target-host localhost", false),
+			Entry("target port without host", "--target-port 7000", false),
 			Entry("debug flag", "--debug", true),
 			Entry("quiet flag", "--quiet", true),
 			Entry("verbose flag", "--verbose", true),

--- a/checkmigrate/wrappers.go
+++ b/checkmigrate/wrappers.go
@@ -73,7 +73,7 @@ func CreateConnectionPool() {
 	}
 	if !sourceConnectionPool.Version.Is("6") {
 		gplog.SetErrorCode(2)
-		panic(errors.Errorf(`Source GPDB version %s is not supported. Utility is used only on GPDB %s as source.`, sourceConnectionPool.Version.VersionString, "6"))
+		panic(errors.New("This utility can only check for migrate from Greengage version 6"))
 	}
 
 	targetHost := options.MustGetFlagString(cmdFlags, options.TARGET_HOST)
@@ -96,7 +96,7 @@ func CreateConnectionPool() {
 		}
 		if !targetConnectionPool.Version.Is("7") {
 			gplog.SetErrorCode(3)
-			panic(errors.Errorf(`Target GPDB version %s is not supported. Utility is used only on GPDB %s as target.`, targetConnectionPool.Version.VersionString, "7"))
+			panic(errors.New("This utility can only check for migrate from Greengage version 6 to Greengage version 7"))
 		}
 	}
 }

--- a/checkmigrate/wrappers.go
+++ b/checkmigrate/wrappers.go
@@ -43,12 +43,14 @@ func CreateConnectionPool() {
 	if sourcePort == 0 {
 		sourcePort = 5432
 		if envPort := os.Getenv("PGPORT"); envPort != "" {
-			envPortInt, _ := strconv.Atoi(envPort)
-			sourcePort = envPortInt
+			envPortInt, conversionError := strconv.Atoi(envPort)
+			if conversionError == nil {
+				sourcePort = envPortInt
+			}
 		}
 	}
 
-	// We will need to check for all DBs if sourceDB not specified, 
+	// We will need to check for all DBs if sourceDB not specified,
 	// but use postgres for initial connection.
 	scrapeDbNames = false
 	if sourceDb == "" {
@@ -65,7 +67,10 @@ func CreateConnectionPool() {
 	}
 
 	sourceConnectionPool = createDBConn(sourceDb, sourceUser, sourceHost, sourcePort)
-	sourceConnectionPool.MustConnect(1)
+	if connectionError := sourceConnectionPool.Connect(1); connectionError != nil {
+		gplog.SetErrorCode(5)
+		panic(connectionError)
+	}
 	if !sourceConnectionPool.Version.Is("6") {
 		gplog.SetErrorCode(2)
 		panic(errors.Errorf(`Source GPDB version %s is not supported. Utility is used only on GPDB %s as source.`, sourceConnectionPool.Version.VersionString, "6"))
@@ -73,7 +78,7 @@ func CreateConnectionPool() {
 
 	targetHost := options.MustGetFlagString(cmdFlags, options.TARGET_HOST)
 	targetPort := options.MustGetFlagInt(cmdFlags, options.TARGET_PORT)
-	targetDb := "postgres" // TBD
+	targetDb := "postgres"
 	targetUser := options.MustGetFlagString(cmdFlags, options.TARGET_USER)
 
 	if targetUser == "" {
@@ -83,13 +88,12 @@ func CreateConnectionPool() {
 		}
 	}
 
-	// Сreate connection to the target cluster only if both flags are provied.
-	if (targetHost != "" || targetPort != 0) && !(targetHost != "" && targetPort != 0) {
-		panic(errors.Errorf("Both -H and -P options need to be provided to check target cluster."))
-	}
 	if targetHost != "" && targetPort != 0 {
 		targetConnectionPool = createDBConn(targetDb, targetUser, targetHost, targetPort)
-		targetConnectionPool.MustConnect(1)
+		if connectionError := targetConnectionPool.Connect(1); connectionError != nil {
+			gplog.SetErrorCode(5)
+			panic(connectionError)
+		}
 		if !targetConnectionPool.Version.Is("7") {
 			gplog.SetErrorCode(3)
 			panic(errors.Errorf(`Target GPDB version %s is not supported. Utility is used only on GPDB %s as target.`, targetConnectionPool.Version.VersionString, "7"))

--- a/checkmigrate/wrappers.go
+++ b/checkmigrate/wrappers.go
@@ -39,14 +39,10 @@ func CreateConnectionPool() {
 	sourceDb := options.MustGetFlagString(cmdFlags, options.SOURCE_DATABASE)
 	sourceUser := options.MustGetFlagString(cmdFlags, options.SOURCE_USER)
 
-	//If port is not passed, grab PGPORT (if defined), else use 5432
-	if sourcePort == 0 {
-		sourcePort = 5432
-		if envPort := os.Getenv("PGPORT"); envPort != "" {
-			envPortInt, conversionError := strconv.Atoi(envPort)
-			if conversionError == nil {
-				sourcePort = envPortInt
-			}
+	if envPort := os.Getenv("PGPORT"); !cmdFlags.Changed(options.SOURCE_PORT) && envPort != "" {
+		envPortInt, conversionError := strconv.Atoi(envPort)
+		if conversionError == nil {
+			sourcePort = envPortInt
 		}
 	}
 
@@ -96,7 +92,7 @@ func CreateConnectionPool() {
 		}
 		if !targetConnectionPool.Version.Is("7") {
 			gplog.SetErrorCode(3)
-			panic(errors.New("This utility can only check for migrate from Greengage version 6 to Greengage version 7"))
+			panic(errors.New("This utility can only check for migrate to Greengage version 7"))
 		}
 	}
 }

--- a/checkmigrate/wrappers.go
+++ b/checkmigrate/wrappers.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/GreengageDB/gp-common-go-libs/dbconn"
 	"github.com/GreengageDB/gp-common-go-libs/gplog"
 	"github.com/GreengageDB/gpbackup/options"
 
@@ -32,10 +31,6 @@ func SetLoggerVerbosity() {
 	}
 }
 
-// TODO: Handle password flags
-//
-// Make two connections for future checks.
-//
 // We kind of replicate NewDBConnFromEnvironment(), but as we have
 // host/port/user flags we need to do their checking and assignment here.
 func CreateConnectionPool() {
@@ -69,12 +64,8 @@ func CreateConnectionPool() {
 		}
 	}
 
-	sourceConnectionPool = dbconn.NewDBConn(sourceDb, sourceUser, sourceHost, sourcePort)
-	err := sourceConnectionPool.Connect(1)
-	if err != nil {
-		gplog.SetErrorCode(5)
-		panic(err)
-	}
+	sourceConnectionPool = createDBConn(sourceDb, sourceUser, sourceHost, sourcePort)
+	sourceConnectionPool.MustConnect(1)
 	if !sourceConnectionPool.Version.Is("6") {
 		gplog.SetErrorCode(2)
 		panic(errors.Errorf(`Source GPDB version %s is not supported. Utility is used only on GPDB %s as source.`, sourceConnectionPool.Version.VersionString, "6"))
@@ -92,15 +83,13 @@ func CreateConnectionPool() {
 		}
 	}
 
-	// TBD with architect
-	// Right now, consider creating connection to the target cluster if both flags are provied.
+	// Сreate connection to the target cluster only if both flags are provied.
+	if (targetHost != "" || targetPort != 0) && !(targetHost != "" && targetPort != 0) {
+		panic(errors.Errorf("Both -H and -P options need to be provided to check target cluster."))
+	}
 	if targetHost != "" && targetPort != 0 {
-		targetConnectionPool = dbconn.NewDBConn(targetDb, targetUser, targetHost, targetPort)
-		err = targetConnectionPool.Connect(1)
-		if err != nil {
-			gplog.SetErrorCode(5)
-			panic(err)
-		}
+		targetConnectionPool = createDBConn(targetDb, targetUser, targetHost, targetPort)
+		targetConnectionPool.MustConnect(1)
 		if !targetConnectionPool.Version.Is("7") {
 			gplog.SetErrorCode(3)
 			panic(errors.Errorf(`Target GPDB version %s is not supported. Utility is used only on GPDB %s as target.`, targetConnectionPool.Version.VersionString, "7"))

--- a/checkmigrate/wrappers.go
+++ b/checkmigrate/wrappers.go
@@ -1,6 +1,9 @@
 package checkmigrate
 
 import (
+	"os"
+	"strconv"
+
 	"github.com/GreengageDB/gp-common-go-libs/dbconn"
 	"github.com/GreengageDB/gp-common-go-libs/gplog"
 	"github.com/GreengageDB/gpbackup/options"
@@ -29,12 +32,44 @@ func SetLoggerVerbosity() {
 	}
 }
 
-// TODO: Handle source and target flags here and pass them to NewDBConn
+// TODO: Handle password flags
 //
-// Also, there seem to be no Conn() function to pass a password to it,
-// Might need to be written.
+// Make two connections for future checks.
+//
+// We kind of replicate NewDBConnFromEnvironment(), but as we have
+// host/port/user flags we need to do their checking and assignment here.
 func CreateConnectionPool() {
-	sourceConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/tmp", 6000)
+	sourceHost := options.MustGetFlagString(cmdFlags, options.SOURCE_HOST)
+	sourcePort := options.MustGetFlagInt(cmdFlags, options.SOURCE_PORT)
+	sourceDb := options.MustGetFlagString(cmdFlags, options.SOURCE_DATABASE)
+	sourceUser := options.MustGetFlagString(cmdFlags, options.SOURCE_USER)
+
+	//If port is not passed, grab PGPORT (if defined), else use 5432
+	if sourcePort == 0 {
+		sourcePort = 5432
+		if envPort := os.Getenv("PGPORT"); envPort != "" {
+			envPortInt, _ := strconv.Atoi(envPort)
+			sourcePort = envPortInt
+		}
+	}
+
+	// We will need to check for all DBs if sourceDB not specified, 
+	// but use postgres for initial connection.
+	scrapeDbNames = false
+	if sourceDb == "" {
+		sourceDb = "postgres"
+		scrapeDbNames = true
+	}
+
+	// Try using PGUSER first, then USER
+	if sourceUser == "" {
+		sourceUser = os.Getenv("USER")
+		if envUser := os.Getenv("PGUSER"); envUser != "" {
+			sourceUser = envUser
+		}
+	}
+
+	sourceConnectionPool = dbconn.NewDBConn(sourceDb, sourceUser, sourceHost, sourcePort)
 	err := sourceConnectionPool.Connect(1)
 	if err != nil {
 		gplog.SetErrorCode(5)
@@ -45,15 +80,30 @@ func CreateConnectionPool() {
 		panic(errors.Errorf(`Source GPDB version %s is not supported. Utility is used only on GPDB %s as source.`, sourceConnectionPool.Version.VersionString, "6"))
 	}
 
-	// TODO: Handle this, only if target-host flag is defined
-	targetConnectionPool = dbconn.NewDBConn("postgres", "gpadmin", "/tmp", 7000)
-	err = targetConnectionPool.Connect(1)
-	if err != nil {
-		gplog.SetErrorCode(5)
-		panic(err)
+	targetHost := options.MustGetFlagString(cmdFlags, options.TARGET_HOST)
+	targetPort := options.MustGetFlagInt(cmdFlags, options.TARGET_PORT)
+	targetDb := "postgres" // TBD
+	targetUser := options.MustGetFlagString(cmdFlags, options.TARGET_USER)
+
+	if targetUser == "" {
+		targetUser = os.Getenv("USER")
+		if envUser := os.Getenv("PGUSER"); envUser != "" {
+			targetUser = envUser
+		}
 	}
-	if !targetConnectionPool.Version.Is("7") {
-		gplog.SetErrorCode(3)
-		panic(errors.Errorf(`Target GPDB version %s is not supported. Utility is used only on GPDB %s as target.`, targetConnectionPool.Version.VersionString, "7"))
+
+	// TBD with architect
+	// Right now, consider creating connection to the target cluster if both flags are provied.
+	if targetHost != "" && targetPort != 0 {
+		targetConnectionPool = dbconn.NewDBConn(targetDb, targetUser, targetHost, targetPort)
+		err = targetConnectionPool.Connect(1)
+		if err != nil {
+			gplog.SetErrorCode(5)
+			panic(err)
+		}
+		if !targetConnectionPool.Version.Is("7") {
+			gplog.SetErrorCode(3)
+			panic(errors.Errorf(`Target GPDB version %s is not supported. Utility is used only on GPDB %s as target.`, targetConnectionPool.Version.VersionString, "7"))
+		}
 	}
 }

--- a/checkmigrate/wrappers_test.go
+++ b/checkmigrate/wrappers_test.go
@@ -1,10 +1,11 @@
 package checkmigrate_test
 
 import (
-	"os"
+	"errors"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/GreengageDB/gp-common-go-libs/dbconn"
+	"github.com/GreengageDB/gp-common-go-libs/gplog"
 	"github.com/GreengageDB/gp-common-go-libs/testhelper"
 	"github.com/GreengageDB/gpbackup/options"
 	"github.com/spf13/pflag"
@@ -35,12 +36,14 @@ var _ = Describe("checkmigrate wrapper tests", func() {
 			checkmigrate.ResetGlobalState()
 			cmdFlags = pflag.NewFlagSet("checkmigrate", pflag.ContinueOnError)
 			checkmigrate.SetCmdFlags(cmdFlags)
+			gplog.SetErrorCode(0)
+			GinkgoT().Setenv("PGPORT", "")
+			GinkgoT().Setenv("PGUSER", "")
 		})
 
 		AfterEach(func() {
-			// Restore the original connection builder
 			checkmigrate.SetCreateDBConn(dbconn.NewDBConn)
-			
+
 			if mockSource != nil {
 				mockSource.Close()
 			}
@@ -50,9 +53,7 @@ var _ = Describe("checkmigrate wrapper tests", func() {
 		})
 
 		It("defaults to port 5432, postgres db, and scrapeDbNames=true when no flags/envs are set", func() {
-			os.Setenv("USER", "test_os_user")
-			
-			defer os.Unsetenv("USER")
+			GinkgoT().Setenv("USER", "test_os_user")
 
 			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
 				mockSource.DBName = dbName
@@ -75,8 +76,7 @@ var _ = Describe("checkmigrate wrapper tests", func() {
 		})
 
 		It("uses PGPORT if the source-port flag is not provided", func() {
-			os.Setenv("PGPORT", "6000")
-			defer os.Unsetenv("PGPORT")
+			GinkgoT().Setenv("PGPORT", "6000")
 
 			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
 				mockSource.DBName = dbName
@@ -94,16 +94,29 @@ var _ = Describe("checkmigrate wrapper tests", func() {
 			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
 		})
 
-		It("panics if only target-host is provided without target-port", func() {
-			_ = cmdFlags.Set(options.TARGET_HOST, "localhost")
+		It("uses port 5432 if PGPORT is invalid", func() {
+			GinkgoT().Setenv("PGPORT", "invalid")
 
 			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
+				mockSource.Port = port
 				return mockSource
 			})
 
-			Expect(func() {
-				checkmigrate.CreateConnectionPool()
-			}).To(Panic())
+			checkmigrate.CreateConnectionPool()
+
+			Expect(checkmigrate.GetSourceConnectionPool().Port).To(Equal(5432))
+			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
+		})
+
+		It("returns execution error code for a source connection failure", func() {
+			failingSource, _ := testhelper.CreateMockDBConn(errors.New("source connection failed"))
+			DeferCleanup(failingSource.Close)
+			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
+				return failingSource
+			})
+
+			Expect(checkmigrate.CreateConnectionPool).To(Panic())
+			Expect(gplog.GetErrorCode()).To(Equal(5))
 		})
 
 		It("successfully creates both source and target connections when target-host and target-port are provided", func() {
@@ -136,6 +149,27 @@ var _ = Describe("checkmigrate wrapper tests", func() {
 
 			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
 			Expect(targetMock.ExpectationsWereMet()).To(Succeed())
+		})
+
+		It("returns execution error code for a target connection failure", func() {
+			failingTarget, _ := testhelper.CreateMockDBConn(errors.New("target connection failed"))
+			DeferCleanup(failingTarget.Close)
+			_ = cmdFlags.Set(options.TARGET_HOST, "localhost")
+			_ = cmdFlags.Set(options.TARGET_PORT, "7000")
+
+			connectionCount := 0
+			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
+				connectionCount++
+				if connectionCount == 1 {
+					return mockSource
+				}
+
+				return failingTarget
+			})
+
+			Expect(checkmigrate.CreateConnectionPool).To(Panic())
+			Expect(gplog.GetErrorCode()).To(Equal(5))
+			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
 		})
 	})
 })

--- a/checkmigrate/wrappers_test.go
+++ b/checkmigrate/wrappers_test.go
@@ -94,6 +94,21 @@ var _ = Describe("checkmigrate wrapper tests", func() {
 			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
 		})
 
+		It("uses the source-port flag when PGPORT is also set", func() {
+			GinkgoT().Setenv("PGPORT", "6000")
+			_ = cmdFlags.Set(options.SOURCE_PORT, "7000")
+
+			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
+				mockSource.Port = port
+				return mockSource
+			})
+
+			checkmigrate.CreateConnectionPool()
+
+			Expect(checkmigrate.GetSourceConnectionPool().Port).To(Equal(7000))
+			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
+		})
+
 		It("uses port 5432 if PGPORT is invalid", func() {
 			GinkgoT().Setenv("PGPORT", "invalid")
 
@@ -202,7 +217,7 @@ var _ = Describe("checkmigrate wrapper tests", func() {
 				return invalidTarget
 			})
 
-			Expect(checkmigrate.CreateConnectionPool).To(PanicWith(MatchError("This utility can only check for migrate from Greengage version 6 to Greengage version 7")))
+			Expect(checkmigrate.CreateConnectionPool).To(PanicWith(MatchError("This utility can only check for migrate to Greengage version 7")))
 			Expect(gplog.GetErrorCode()).To(Equal(3))
 			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
 			Expect(invalidTargetMock.ExpectationsWereMet()).To(Succeed())

--- a/checkmigrate/wrappers_test.go
+++ b/checkmigrate/wrappers_test.go
@@ -1,0 +1,141 @@
+package checkmigrate_test
+
+import (
+	"os"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/GreengageDB/gp-common-go-libs/dbconn"
+	"github.com/GreengageDB/gp-common-go-libs/testhelper"
+	"github.com/GreengageDB/gpbackup/options"
+	"github.com/spf13/pflag"
+
+	"github.com/GreengageDB/gpbackup/checkmigrate"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("checkmigrate wrapper tests", func() {
+	Describe("CreateConnectionPool", func() {
+		var (
+			mockSource *dbconn.DBConn
+			mockTarget *dbconn.DBConn
+			sourceMock sqlmock.Sqlmock
+			targetMock sqlmock.Sqlmock
+			cmdFlags   *pflag.FlagSet
+		)
+
+		BeforeEach(func() {
+			mockSource, sourceMock = testhelper.CreateMockDBConn()
+			mockTarget, targetMock = testhelper.CreateMockDBConn()
+			testhelper.SetDBVersion(mockSource, "6.0.0")
+			testhelper.SetDBVersion(mockTarget, "7.0.0")
+			testhelper.ExpectVersionQuery(sourceMock, "6.0.0")
+			testhelper.ExpectVersionQuery(targetMock, "7.0.0")
+			checkmigrate.ResetGlobalState()
+			cmdFlags = pflag.NewFlagSet("checkmigrate", pflag.ContinueOnError)
+			checkmigrate.SetCmdFlags(cmdFlags)
+		})
+
+		AfterEach(func() {
+			// Restore the original connection builder
+			checkmigrate.SetCreateDBConn(dbconn.NewDBConn)
+			
+			if mockSource != nil {
+				mockSource.Close()
+			}
+			if mockTarget != nil {
+				mockTarget.Close()
+			}
+		})
+
+		It("defaults to port 5432, postgres db, and scrapeDbNames=true when no flags/envs are set", func() {
+			os.Setenv("USER", "test_os_user")
+			
+			defer os.Unsetenv("USER")
+
+			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
+				mockSource.DBName = dbName
+				mockSource.User = username
+				mockSource.Host = host
+				mockSource.Port = port
+				return mockSource
+			})
+
+			checkmigrate.CreateConnectionPool()
+
+			sourcePool := checkmigrate.GetSourceConnectionPool()
+			Expect(sourcePool).NotTo(BeNil())
+			Expect(sourcePool.Port).To(Equal(5432))
+			Expect(sourcePool.DBName).To(Equal("postgres"))
+			Expect(sourcePool.User).To(Equal("test_os_user"))
+			Expect(checkmigrate.GetScrapeDbNames()).To(BeTrue())
+
+			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
+		})
+
+		It("uses PGPORT if the source-port flag is not provided", func() {
+			os.Setenv("PGPORT", "6000")
+			defer os.Unsetenv("PGPORT")
+
+			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
+				mockSource.DBName = dbName
+				mockSource.User = username
+				mockSource.Host = host
+				mockSource.Port = port
+				return mockSource
+			})
+
+			checkmigrate.CreateConnectionPool()
+
+			sourcePool := checkmigrate.GetSourceConnectionPool()
+			Expect(sourcePool).NotTo(BeNil())
+			Expect(sourcePool.Port).To(Equal(6000))
+			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
+		})
+
+		It("panics if only target-host is provided without target-port", func() {
+			_ = cmdFlags.Set(options.TARGET_HOST, "localhost")
+
+			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
+				return mockSource
+			})
+
+			Expect(func() {
+				checkmigrate.CreateConnectionPool()
+			}).To(Panic())
+		})
+
+		It("successfully creates both source and target connections when target-host and target-port are provided", func() {
+			_ = cmdFlags.Set(options.TARGET_HOST, "localhost")
+			_ = cmdFlags.Set(options.TARGET_PORT, "7000")
+
+			callCount := 0
+			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
+				callCount++
+				if callCount == 1 {
+					mockSource.DBName = dbName
+					mockSource.User = username
+					mockSource.Host = host
+					mockSource.Port = port
+					return mockSource
+				}
+				mockTarget.DBName = dbName
+				mockTarget.User = username
+				mockTarget.Host = host
+				mockTarget.Port = port
+				return mockTarget
+			})
+
+			checkmigrate.CreateConnectionPool()
+
+			targetPool := checkmigrate.GetTargetConnectionPool()
+			Expect(targetPool).NotTo(BeNil())
+			Expect(targetPool.Host).To(Equal("localhost"))
+			Expect(targetPool.Port).To(Equal(7000))
+
+			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
+			Expect(targetMock.ExpectationsWereMet()).To(Succeed())
+		})
+	})
+})

--- a/checkmigrate/wrappers_test.go
+++ b/checkmigrate/wrappers_test.go
@@ -119,6 +119,19 @@ var _ = Describe("checkmigrate wrapper tests", func() {
 			Expect(gplog.GetErrorCode()).To(Equal(5))
 		})
 
+		It("returns the documented error for an invalid source version", func() {
+			invalidSource, invalidSourceMock := testhelper.CreateMockDBConn()
+			testhelper.ExpectVersionQuery(invalidSourceMock, "5.0.0")
+			DeferCleanup(invalidSource.Close)
+			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
+				return invalidSource
+			})
+
+			Expect(checkmigrate.CreateConnectionPool).To(PanicWith(MatchError("This utility can only check for migrate from Greengage version 6")))
+			Expect(gplog.GetErrorCode()).To(Equal(2))
+			Expect(invalidSourceMock.ExpectationsWereMet()).To(Succeed())
+		})
+
 		It("successfully creates both source and target connections when target-host and target-port are provided", func() {
 			_ = cmdFlags.Set(options.TARGET_HOST, "localhost")
 			_ = cmdFlags.Set(options.TARGET_PORT, "7000")
@@ -170,6 +183,29 @@ var _ = Describe("checkmigrate wrapper tests", func() {
 			Expect(checkmigrate.CreateConnectionPool).To(Panic())
 			Expect(gplog.GetErrorCode()).To(Equal(5))
 			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
+		})
+
+		It("returns the documented error for an invalid target version", func() {
+			invalidTarget, invalidTargetMock := testhelper.CreateMockDBConn()
+			testhelper.ExpectVersionQuery(invalidTargetMock, "8.0.0")
+			DeferCleanup(invalidTarget.Close)
+			_ = cmdFlags.Set(options.TARGET_HOST, "localhost")
+			_ = cmdFlags.Set(options.TARGET_PORT, "7000")
+
+			connectionCount := 0
+			checkmigrate.SetCreateDBConn(func(dbName, username, host string, port int) *dbconn.DBConn {
+				connectionCount++
+				if connectionCount == 1 {
+					return mockSource
+				}
+
+				return invalidTarget
+			})
+
+			Expect(checkmigrate.CreateConnectionPool).To(PanicWith(MatchError("This utility can only check for migrate from Greengage version 6 to Greengage version 7")))
+			Expect(gplog.GetErrorCode()).To(Equal(3))
+			Expect(sourceMock.ExpectationsWereMet()).To(Succeed())
+			Expect(invalidTargetMock.ExpectationsWereMet()).To(Succeed())
 		})
 	})
 })

--- a/options/flag.go
+++ b/options/flag.go
@@ -62,11 +62,9 @@ const (
 	SOURCE_PORT        = "source-port"
 	SOURCE_DATABASE    = "source-database"
 	SOURCE_USER        = "source-user"
-	SOURCE_NO_PASSWORD = "source-no-password"
 	TARGET_HOST        = "target-host"
 	TARGET_PORT        = "target-port"
 	TARGET_USER        = "target-user"
-	TARGET_NO_PASSWORD = "target-no-password"
 )
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
@@ -145,11 +143,9 @@ func SetCheckMigrateFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.IntP(SOURCE_PORT, "p", 0, "The port of the cluster being checked")
 	flagSet.StringP(SOURCE_DATABASE, "d", "", "The database of the cluster being checked")
 	flagSet.StringP(SOURCE_USER, "u", "", "The superuser of the cluster being checked")
-	flagSet.BoolP(SOURCE_NO_PASSWORD, "w", false, "Never prompt for the source cluster password")
 	flagSet.StringP(TARGET_HOST, "H", "", "The host of the cluster of next version")
 	flagSet.IntP(TARGET_PORT, "P", 0, "The port of the cluster of next version")
 	flagSet.StringP(TARGET_USER, "U", "", "The superuser of the cluster being checked")
-	flagSet.BoolP(TARGET_NO_PASSWORD, "W", false, "Never prompt for the target cluster password")
 	flagSet.BoolP("help", "?", false, "Help for ggcheckmigrate")
 	flagSet.BoolP("version", "v", false, "Print version number and exit")
 	flagSet.Bool(DEBUG, false, "Print verbose and debug log messages")

--- a/options/flag.go
+++ b/options/flag.go
@@ -58,13 +58,13 @@ const (
 	/*
 	 *	ggcheckmigrate-specific flags
 	 */
-	SOURCE_HOST        = "source-host"
-	SOURCE_PORT        = "source-port"
-	SOURCE_DATABASE    = "source-database"
-	SOURCE_USER        = "source-user"
-	TARGET_HOST        = "target-host"
-	TARGET_PORT        = "target-port"
-	TARGET_USER        = "target-user"
+	SOURCE_HOST     = "source-host"
+	SOURCE_PORT     = "source-port"
+	SOURCE_DATABASE = "source-database"
+	SOURCE_USER     = "source-user"
+	TARGET_HOST     = "target-host"
+	TARGET_PORT     = "target-port"
+	TARGET_USER     = "target-user"
 )
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
@@ -140,7 +140,7 @@ func SetRestoreFlagDefaults(flagSet *pflag.FlagSet) {
 
 func SetCheckMigrateFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.StringP(SOURCE_HOST, "h", "/tmp", "The host of the cluster being checked")
-	flagSet.IntP(SOURCE_PORT, "p", 0, "The port of the cluster being checked")
+	flagSet.IntP(SOURCE_PORT, "p", 5432, "The port of the cluster being checked")
 	flagSet.StringP(SOURCE_DATABASE, "d", "", "The database of the cluster being checked")
 	flagSet.StringP(SOURCE_USER, "u", "", "The superuser of the cluster being checked")
 	flagSet.StringP(TARGET_HOST, "H", "", "The host of the cluster of next version")

--- a/options/flag.go
+++ b/options/flag.go
@@ -141,13 +141,13 @@ func SetRestoreFlagDefaults(flagSet *pflag.FlagSet) {
 }
 
 func SetCheckMigrateFlagDefaults(flagSet *pflag.FlagSet) {
-	flagSet.StringP(SOURCE_HOST, "h", "", "The host of the cluster being checked")
-	flagSet.StringP(SOURCE_PORT, "p", "", "The port of the cluster being checked")
+	flagSet.StringP(SOURCE_HOST, "h", "/tmp", "The host of the cluster being checked")
+	flagSet.IntP(SOURCE_PORT, "p", 0, "The port of the cluster being checked")
 	flagSet.StringP(SOURCE_DATABASE, "d", "", "The database of the cluster being checked")
 	flagSet.StringP(SOURCE_USER, "u", "", "The superuser of the cluster being checked")
 	flagSet.BoolP(SOURCE_NO_PASSWORD, "w", false, "Never prompt for the source cluster password")
 	flagSet.StringP(TARGET_HOST, "H", "", "The host of the cluster of next version")
-	flagSet.StringP(TARGET_PORT, "P", "", "The port of the cluster of next version")
+	flagSet.IntP(TARGET_PORT, "P", 0, "The port of the cluster of next version")
 	flagSet.StringP(TARGET_USER, "U", "", "The superuser of the cluster being checked")
 	flagSet.BoolP(TARGET_NO_PASSWORD, "W", false, "Never prompt for the target cluster password")
 	flagSet.BoolP("help", "?", false, "Help for ggcheckmigrate")


### PR DESCRIPTION
What is it?
After merging implementation of utilitty functions and option parsing,
connection creation (CreateConnectionPool()) with parsed flags is still needed.
This PR implements exactly this. Also uses default values if no flag provided
according to SRS.

Ticket: GG-651