### PR TITLE
GG-643: Fix gprestore --redirect-schema for tables with complex partitioning

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1139,20 +1139,20 @@ var _ = Describe("backup and restore end to end tests", func() {
 				"DROP SCHEMA foo CASCADE")
 			testhelper.AssertQueryRuns(backupConn,
 				`CREATE TABLE foo.foo (id int, id2 int, id3 int)
-					PARTITION BY RANGE (id) 
-						SUBPARTITION BY LIST (id) 
+					PARTITION BY RANGE (id)
+						SUBPARTITION BY LIST (id)
 							SUBPARTITION TEMPLATE (
-								SUBPARTITION a VALUES (1), 
+								SUBPARTITION a VALUES (1),
 								DEFAULT SUBPARTITION b
-							) 
-							SUBPARTITION BY LIST (id2) 
+							)
+							SUBPARTITION BY LIST (id2)
 								SUBPARTITION TEMPLATE (
-									SUBPARTITION c VALUES (2), 
+									SUBPARTITION c VALUES (2),
 									DEFAULT SUBPARTITION d
-									) 
-									SUBPARTITION BY LIST (id3) 
+									)
+									SUBPARTITION BY LIST (id3)
 										SUBPARTITION TEMPLATE (
-											SUBPARTITION e VALUES(3), 
+											SUBPARTITION e VALUES(3),
 											DEFAULT SUBPARTITION f)
 					(
 						START (1) END (10) EVERY (10)

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1127,6 +1127,30 @@ var _ = Describe("backup and restore end to end tests", func() {
 				`SELECT count(*) FROM pg_statistic WHERE starelid='schema3.foo3'::regclass::oid;`)
 			Expect(actualStatisticCount).To(Equal("1"))
 		})
+		It("runs gprestore with --redirect-schema and table with subpartition template", func() {
+			skipIfOldBackupVersionBefore("1.17.0")
+			testhelper.AssertQueryRuns(restoreConn,
+				"DROP SCHEMA IF EXISTS schema3 CASCADE; CREATE SCHEMA schema3;")
+			defer testhelper.AssertQueryRuns(restoreConn,
+				"DROP SCHEMA schema3 CASCADE")
+			testhelper.AssertQueryRuns(backupConn,
+				"CREATE SCHEMA foo")
+			defer testhelper.AssertQueryRuns(backupConn,
+				"DROP SCHEMA foo CASCADE")
+			testhelper.AssertQueryRuns(backupConn,
+				"CREATE TABLE foo.foo (id int, id2 int, id3 int) PARTITION BY RANGE (id) SUBPARTITION BY LIST (id) SUBPARTITION TEMPLATE (SUBPARTITION a VALUES (1), SUBPARTITION b VALUES (2), DEFAULT SUBPARTITION c) SUBPARTITION BY LIST (id2) SUBPARTITION TEMPLATE (SUBPARTITION d VALUES (3), subpartition e values(4), DEFAULT SUBPARTITION f) SUBPARTITION BY LIST (id3) SUBPARTITION TEMPLATE (SUBPARTITION g VALUES(5), SUBPARTITION h VALUES(6), DEFAULT SUBPARTITION i) (START (1) END (10) EVERY (5));")
+
+			output := gpbackup(gpbackupPath, backupHelperPath)
+			timestamp := getBackupTimestamp(string(output))
+
+			gprestore(gprestorePath, restoreHelperPath, timestamp,
+				"--include-table", "foo.foo",
+				"--redirect-db", "restoredb",
+				"--redirect-schema", "schema3")
+
+			assertRelationsCreatedInSchema(restoreConn, "schema3", 1)
+			assertDataRestored(restoreConn, map[string]int{"schema3.foo": 0})
+		})
 		It("runs gprestore with --redirect-schema and multiple included schemas", func() {
 			skipIfOldBackupVersionBefore("1.17.0")
 			testhelper.AssertQueryRuns(restoreConn,

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1138,7 +1138,25 @@ var _ = Describe("backup and restore end to end tests", func() {
 			defer testhelper.AssertQueryRuns(backupConn,
 				"DROP SCHEMA foo CASCADE")
 			testhelper.AssertQueryRuns(backupConn,
-				"CREATE TABLE foo.foo (id int, id2 int, id3 int) PARTITION BY RANGE (id) SUBPARTITION BY LIST (id) SUBPARTITION TEMPLATE (SUBPARTITION a VALUES (1), SUBPARTITION b VALUES (2), DEFAULT SUBPARTITION c) SUBPARTITION BY LIST (id2) SUBPARTITION TEMPLATE (SUBPARTITION d VALUES (3), subpartition e values(4), DEFAULT SUBPARTITION f) SUBPARTITION BY LIST (id3) SUBPARTITION TEMPLATE (SUBPARTITION g VALUES(5), SUBPARTITION h VALUES(6), DEFAULT SUBPARTITION i) (START (1) END (10) EVERY (5));")
+				`CREATE TABLE foo.foo (id int, id2 int, id3 int)
+					PARTITION BY RANGE (id) 
+						SUBPARTITION BY LIST (id) 
+							SUBPARTITION TEMPLATE (
+								SUBPARTITION a VALUES (1), 
+								DEFAULT SUBPARTITION b
+							) 
+							SUBPARTITION BY LIST (id2) 
+								SUBPARTITION TEMPLATE (
+									SUBPARTITION c VALUES (2), 
+									DEFAULT SUBPARTITION d
+									) 
+									SUBPARTITION BY LIST (id3) 
+										SUBPARTITION TEMPLATE (
+											SUBPARTITION e VALUES(3), 
+											DEFAULT SUBPARTITION f)
+					(
+						START (1) END (10) EVERY (10)
+					);`)
 
 			output := gpbackup(gpbackupPath, backupHelperPath)
 			timestamp := getBackupTimestamp(string(output))
@@ -1148,7 +1166,7 @@ var _ = Describe("backup and restore end to end tests", func() {
 				"--redirect-db", "restoredb",
 				"--redirect-schema", "schema3")
 
-			assertRelationsCreatedInSchema(restoreConn, "schema3", 1)
+			assertRelationsCreatedInSchema(restoreConn, "schema3", 8)
 			assertDataRestored(restoreConn, map[string]int{"schema3.foo": 0})
 		})
 		It("runs gprestore with --redirect-schema and multiple included schemas", func() {

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1166,7 +1166,7 @@ var _ = Describe("backup and restore end to end tests", func() {
 				"--redirect-db", "restoredb",
 				"--redirect-schema", "schema3")
 
-			assertRelationsCreatedInSchema(restoreConn, "schema3", 8)
+			assertRelationsCreatedInSchema(restoreConn, "schema3", 16)
 			assertDataRestored(restoreConn, map[string]int{"schema3.foo": 0})
 		})
 		It("runs gprestore with --redirect-schema and multiple included schemas", func() {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -414,6 +414,8 @@ func editStatementsRedirectSchema(statements []toc.StatementWithType, redirectSc
 	schemaMatch := `(?:".+?"|[^."]+?)` // matches either an unquoted schema with no dots or quotes or a quoted schema containing dots
 	// This expression matches a GRANT or REVOKE statement on any object and captures the old schema name
 	permissionsRE := regexp.MustCompile(fmt.Sprintf(`(?m)(^(?:REVOKE|GRANT) .+ ON .+?) (%s)((\..+)? (?:FROM|TO) .+)`, schemaMatch))
+	// This expression matches an ALTER PARTITION ... SET SUBPARTITION TEMPLATE statement and captures old schema name
+	alterPartitionRE := regexp.MustCompile(fmt.Sprintf(`(ALTER TABLE(?: ONLY)?) (%s)(\..+)( ALTER PARTITION (?:.+))*(\nSET SUBPARTITION TEMPLATE)`, schemaMatch))
 	// This expression matches an ATTACH PARTITION statement and captures both the parent and child schema names
 	attachRE := regexp.MustCompile(fmt.Sprintf(`(ALTER TABLE(?: ONLY)?) (%[1]s)(\..+ ATTACH PARTITION) (%[1]s)(\..+)`, schemaMatch))
 	// This expression matches a '<schema>.<table>'::regclass::oid expression.
@@ -438,6 +440,13 @@ func editStatementsRedirectSchema(statements []toc.StatementWithType, redirectSc
 		if strings.Contains(statement, "GRANT") || strings.Contains(statement, "REVOKE") {
 			statement = permissionsRE.ReplaceAllString(statement, fmt.Sprintf("$1 %s$3", redirectSchema))
 			replaced = true
+		}
+
+		// After CREATE TABLE there can be ALTER TABLE ... SET SUBPARTITION TEMPLATE queries,
+		// which will have schema qualified tables.
+		// Also don't set replaced, as otherwise we won't change CREATE TABLE schema.
+		if statements[i].ObjectType == toc.OBJ_TABLE && strings.Contains(statement, "SET SUBPARTITION TEMPLATE") {
+			statement = alterPartitionRE.ReplaceAllString(statement, fmt.Sprintf("$1 %[1]s$3 $4$5", redirectSchema))
 		}
 
 		// ALTER TABLE schema.root ATTACH PARTITION schema.leaf needs two schema replacements

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -415,7 +415,7 @@ func editStatementsRedirectSchema(statements []toc.StatementWithType, redirectSc
 	// This expression matches a GRANT or REVOKE statement on any object and captures the old schema name
 	permissionsRE := regexp.MustCompile(fmt.Sprintf(`(?m)(^(?:REVOKE|GRANT) .+ ON .+?) (%s)((\..+)? (?:FROM|TO) .+)`, schemaMatch))
 	// This expression matches an ALTER PARTITION ... SET SUBPARTITION TEMPLATE statement and captures old schema name
-	alterPartitionRE := regexp.MustCompile(fmt.Sprintf(`(ALTER TABLE(?: ONLY)?) (%s)(\..+) (ALTER PARTITION (?:.+) )*(\nSET SUBPARTITION TEMPLATE)`, schemaMatch))
+	alterPartitionRE := regexp.MustCompile(fmt.Sprintf(`(ALTER TABLE(?: ONLY)?) (%s)(\..+?) ((?:ALTER PARTITION (?:.+?) )*?)(\nSET SUBPARTITION TEMPLATE)`, schemaMatch))
 	// This expression matches an ATTACH PARTITION statement and captures both the parent and child schema names
 	attachRE := regexp.MustCompile(fmt.Sprintf(`(ALTER TABLE(?: ONLY)?) (%[1]s)(\..+ ATTACH PARTITION) (%[1]s)(\..+)`, schemaMatch))
 	// This expression matches a '<schema>.<table>'::regclass::oid expression.

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -415,7 +415,7 @@ func editStatementsRedirectSchema(statements []toc.StatementWithType, redirectSc
 	// This expression matches a GRANT or REVOKE statement on any object and captures the old schema name
 	permissionsRE := regexp.MustCompile(fmt.Sprintf(`(?m)(^(?:REVOKE|GRANT) .+ ON .+?) (%s)((\..+)? (?:FROM|TO) .+)`, schemaMatch))
 	// This expression matches an ALTER PARTITION ... SET SUBPARTITION TEMPLATE statement and captures old schema name
-	alterPartitionRE := regexp.MustCompile(fmt.Sprintf(`(ALTER TABLE(?: ONLY)?) (%s)(\..+)( ALTER PARTITION (?:.+))*(\nSET SUBPARTITION TEMPLATE)`, schemaMatch))
+	alterPartitionRE := regexp.MustCompile(fmt.Sprintf(`(ALTER TABLE(?: ONLY)?) (%s)(\..+) (ALTER PARTITION (?:.+) )*(\nSET SUBPARTITION TEMPLATE)`, schemaMatch))
 	// This expression matches an ATTACH PARTITION statement and captures both the parent and child schema names
 	attachRE := regexp.MustCompile(fmt.Sprintf(`(ALTER TABLE(?: ONLY)?) (%[1]s)(\..+ ATTACH PARTITION) (%[1]s)(\..+)`, schemaMatch))
 	// This expression matches a '<schema>.<table>'::regclass::oid expression.
@@ -446,7 +446,7 @@ func editStatementsRedirectSchema(statements []toc.StatementWithType, redirectSc
 		// which will have schema qualified tables.
 		// Also don't set replaced, as otherwise we won't change CREATE TABLE schema.
 		if statements[i].ObjectType == toc.OBJ_TABLE && strings.Contains(statement, "SET SUBPARTITION TEMPLATE") {
-			statement = alterPartitionRE.ReplaceAllString(statement, fmt.Sprintf("$1 %[1]s$3 $4$5", redirectSchema))
+			statement = alterPartitionRE.ReplaceAllString(statement, fmt.Sprintf("$1 %[1]s$3$4$5", redirectSchema))
 		}
 
 		// ALTER TABLE schema.root ATTACH PARTITION schema.leaf needs two schema replacements

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -446,7 +446,7 @@ func editStatementsRedirectSchema(statements []toc.StatementWithType, redirectSc
 		// which will have schema qualified tables.
 		// Also don't set replaced, as otherwise we won't change CREATE TABLE schema.
 		if statements[i].ObjectType == toc.OBJ_TABLE && strings.Contains(statement, "SET SUBPARTITION TEMPLATE") {
-			statement = alterPartitionRE.ReplaceAllString(statement, fmt.Sprintf("$1 %[1]s$3$4$5", redirectSchema))
+			statement = alterPartitionRE.ReplaceAllString(statement, fmt.Sprintf("$1 %[1]s$3 $4$5", redirectSchema))
 		}
 
 		// ALTER TABLE schema.root ATTACH PARTITION schema.leaf needs two schema replacements

--- a/restore/restore_internal_test.go
+++ b/restore/restore_internal_test.go
@@ -52,19 +52,19 @@ var _ = Describe("restore internal tests", func() {
 		},
 		{ // 1 level SET SUBPARTITION TEMPLATE
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
-			Statement: "\n\nALTER TABLE foo.foo\nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION a VALUES(1) WITH (tablename='foo'),\nSUBPARTITION b VALUES(2) WITH (tablename='foo'),\nDEFAULT SUBPARTITION c  WITH (tablename='foo')\n);\n",
+			Statement: "\n\nCREATE TABLE foo.foo (\n\ti integer\n) DISTRIBUTED BY (i);\nALTER TABLE foo.foo \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION a VALUES(1) WITH (tablename='foo'),\nSUBPARTITION b VALUES(2) WITH (tablename='foo'),\nDEFAULT SUBPARTITION c  WITH (tablename='foo')\n);\n",
 		},
 		{ // 2 level SET SUBPARTITION TEMPLATE with partition name
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
-			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION a \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
+			Statement: "\n\nCREATE TABLE foo.foo (\n\ti integer\n) DISTRIBUTED BY (i);\nALTER TABLE foo.foo ALTER PARTITION a \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 		},
 		{ // 2 level SET SUBPARTITION TEMPLATE with FOR (RANK)
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
-			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION FOR (RANK(1)) \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
+			Statement: "\n\nCREATE TABLE foo.foo (\n\ti integer\n) DISTRIBUTED BY (i);\nALTER TABLE foo.foo ALTER PARTITION FOR (RANK(1)) \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 		},
 		{ // 3 level SET SUBPARTITION TEMPLATE
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
-			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION a ALTER PARTITION b \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
+			Statement: "\n\nCREATE TABLE foo.foo (\n\ti integer\n) DISTRIBUTED BY (i);\nALTER TABLE foo.foo ALTER PARTITION a ALTER PARTITION b \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 		},
 		{ // ALTER TABLE ... ATTACH PARTITION statement
 			Schema: "public", Name: "foopart_p1", ObjectType: toc.OBJ_TABLE, ReferenceObject: "public.foopart",
@@ -184,19 +184,19 @@ var _ = Describe("restore internal tests", func() {
 				},
 				{
 					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
-					Statement: "\n\nALTER TABLE foo2.foo\nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION a VALUES(1) WITH (tablename='foo'),\nSUBPARTITION b VALUES(2) WITH (tablename='foo'),\nDEFAULT SUBPARTITION c  WITH (tablename='foo')\n);\n",
+					Statement: "\n\nCREATE TABLE foo2.foo (\n\ti integer\n) DISTRIBUTED BY (i);\nALTER TABLE foo2.foo \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION a VALUES(1) WITH (tablename='foo'),\nSUBPARTITION b VALUES(2) WITH (tablename='foo'),\nDEFAULT SUBPARTITION c  WITH (tablename='foo')\n);\n",
 				},
 				{
 					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
-					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION a \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
+					Statement: "\n\nCREATE TABLE foo2.foo (\n\ti integer\n) DISTRIBUTED BY (i);\nALTER TABLE foo2.foo ALTER PARTITION a \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 				},
 				{
 					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
-					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION FOR (RANK(1)) \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
+					Statement: "\n\nCREATE TABLE foo2.foo (\n\ti integer\n) DISTRIBUTED BY (i);\nALTER TABLE foo2.foo ALTER PARTITION FOR (RANK(1)) \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 				},
 				{
 					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
-					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION a ALTER PARTITION b \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
+					Statement: "\n\nCREATE TABLE foo2.foo (\n\ti integer\n) DISTRIBUTED BY (i);\nALTER TABLE foo2.foo ALTER PARTITION a ALTER PARTITION b \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 				},
 				{ // ALTER TABLE ... ATTACH PARTITION statement
 					Schema: "foo2", Name: "foopart_p1", ObjectType: toc.OBJ_TABLE, ReferenceObject: "foo2.foopart",

--- a/restore/restore_internal_test.go
+++ b/restore/restore_internal_test.go
@@ -52,19 +52,19 @@ var _ = Describe("restore internal tests", func() {
 		},
 		{ // 1 level SET SUBPARTITION TEMPLATE
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
-			Statement: "\n\nALTER TABLE foo.foo\nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION a VALUES(1) WITH (tablename='foo'),\n          SUBPARTITION b VALUES(2) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION c  WITH (tablename='foo')\n          );\n",
+			Statement: "\n\nALTER TABLE foo.foo\nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION a VALUES(1) WITH (tablename='foo'),\nSUBPARTITION b VALUES(2) WITH (tablename='foo'),\nDEFAULT SUBPARTITION c  WITH (tablename='foo')\n);\n",
 		},
 		{ // 2 level SET SUBPARTITION TEMPLATE with partition name
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
-			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION a \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION a \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 		},
 		{ // 2 level SET SUBPARTITION TEMPLATE with FOR (RANK)
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
-			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION FOR (RANK(1)) \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION FOR (RANK(1)) \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 		},
 		{ // 3 level SET SUBPARTITION TEMPLATE
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
-			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION a ALTER PARTITION b \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION a ALTER PARTITION b \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 		},
 		{ // ALTER TABLE ... ATTACH PARTITION statement
 			Schema: "public", Name: "foopart_p1", ObjectType: toc.OBJ_TABLE, ReferenceObject: "public.foopart",
@@ -184,19 +184,19 @@ var _ = Describe("restore internal tests", func() {
 				},
 				{
 					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
-					Statement: "\n\nALTER TABLE foo2.foo\nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION a VALUES(1) WITH (tablename='foo'),\n          SUBPARTITION b VALUES(2) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION c  WITH (tablename='foo')\n          );\n",
+					Statement: "\n\nALTER TABLE foo2.foo\nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION a VALUES(1) WITH (tablename='foo'),\nSUBPARTITION b VALUES(2) WITH (tablename='foo'),\nDEFAULT SUBPARTITION c  WITH (tablename='foo')\n);\n",
 				},
 				{
 					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
-					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION a \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION a \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 				},
 				{
 					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
-					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION FOR (RANK(1)) \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION FOR (RANK(1)) \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 				},
 				{
 					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
-					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION a ALTER PARTITION b \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION a ALTER PARTITION b \nSET SUBPARTITION TEMPLATE \n(\nSUBPARTITION d VALUES(3) WITH (tablename='foo'),\nDEFAULT SUBPARTITION e  WITH (tablename='foo')\n);\n",
 				},
 				{ // ALTER TABLE ... ATTACH PARTITION statement
 					Schema: "foo2", Name: "foopart_p1", ObjectType: toc.OBJ_TABLE, ReferenceObject: "foo2.foopart",

--- a/restore/restore_internal_test.go
+++ b/restore/restore_internal_test.go
@@ -50,6 +50,14 @@ var _ = Describe("restore internal tests", func() {
 			Schema: "\"foo.bar\"", Name: "myfunc", ObjectType: toc.OBJ_FUNCTION,
 			Statement: "\n\nREVOKE ALL ON FUNCTION \"foo.bar\".myfunc(integer) FROM PUBLIC;\nGRANT ALL ON FUNCTION \"foo.bar\".myfunc(integer) TO testuser;\n",
 		},
+		{ // 1 level SET SUBPARTITION TEMPLATE
+			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
+			Statement: "\n\nALTER TABLE foo.foo\nSET SUBPARTITION TEMPLATE\n          (\n          SUBPARTITION a VALUES(1) WITH (tablename='foo'),\n          SUBPARTITION b VALUES(2) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION c  WITH (tablename='foo')\n          );\n",
+		},
+		{ // 2 level SET SUBPARTITION TEMPLATE with FOR (RANK)
+			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
+			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION FOR (RANK(1))\nSET SUBPARTITION TEMPLATE\n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+		},
 		{ // ALTER TABLE ... ATTACH PARTITION statement
 			Schema: "public", Name: "foopart_p1", ObjectType: toc.OBJ_TABLE, ReferenceObject: "public.foopart",
 			Statement: "\n\nALTER TABLE public.foopart ATTACH PARTITION public.foopart_p1 FOR VALUES FROM (0) TO (1);\n",
@@ -165,6 +173,14 @@ var _ = Describe("restore internal tests", func() {
 				{
 					Schema: "foo2", Name: "myfunc", ObjectType: toc.OBJ_FUNCTION,
 					Statement: "\n\nREVOKE ALL ON FUNCTION foo2.myfunc(integer) FROM PUBLIC;\nGRANT ALL ON FUNCTION foo2.myfunc(integer) TO testuser;\n",
+				},
+				{
+					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
+					Statement: "\n\nALTER TABLE foo2.foo\nSET SUBPARTITION TEMPLATE\n          (\n          SUBPARTITION a VALUES(1) WITH (tablename='foo'),\n          SUBPARTITION b VALUES(2) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION c  WITH (tablename='foo')\n          );\n",
+				},
+				{
+					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
+					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION FOR (RANK(1))\nSET SUBPARTITION TEMPLATE\n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
 				},
 				{ // ALTER TABLE ... ATTACH PARTITION statement
 					Schema: "foo2", Name: "foopart_p1", ObjectType: toc.OBJ_TABLE, ReferenceObject: "foo2.foopart",

--- a/restore/restore_internal_test.go
+++ b/restore/restore_internal_test.go
@@ -52,11 +52,19 @@ var _ = Describe("restore internal tests", func() {
 		},
 		{ // 1 level SET SUBPARTITION TEMPLATE
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
-			Statement: "\n\nALTER TABLE foo.foo\nSET SUBPARTITION TEMPLATE\n          (\n          SUBPARTITION a VALUES(1) WITH (tablename='foo'),\n          SUBPARTITION b VALUES(2) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION c  WITH (tablename='foo')\n          );\n",
+			Statement: "\n\nALTER TABLE foo.foo\nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION a VALUES(1) WITH (tablename='foo'),\n          SUBPARTITION b VALUES(2) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION c  WITH (tablename='foo')\n          );\n",
+		},
+		{ // 2 level SET SUBPARTITION TEMPLATE with partition name
+			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
+			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION a \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
 		},
 		{ // 2 level SET SUBPARTITION TEMPLATE with FOR (RANK)
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
-			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION FOR (RANK(1))\nSET SUBPARTITION TEMPLATE\n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION FOR (RANK(1)) \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+		},
+		{ // 3 level SET SUBPARTITION TEMPLATE
+			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_TABLE,
+			Statement: "\n\nALTER TABLE foo.foo ALTER PARTITION a ALTER PARTITION b \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
 		},
 		{ // ALTER TABLE ... ATTACH PARTITION statement
 			Schema: "public", Name: "foopart_p1", ObjectType: toc.OBJ_TABLE, ReferenceObject: "public.foopart",
@@ -176,11 +184,19 @@ var _ = Describe("restore internal tests", func() {
 				},
 				{
 					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
-					Statement: "\n\nALTER TABLE foo2.foo\nSET SUBPARTITION TEMPLATE\n          (\n          SUBPARTITION a VALUES(1) WITH (tablename='foo'),\n          SUBPARTITION b VALUES(2) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION c  WITH (tablename='foo')\n          );\n",
+					Statement: "\n\nALTER TABLE foo2.foo\nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION a VALUES(1) WITH (tablename='foo'),\n          SUBPARTITION b VALUES(2) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION c  WITH (tablename='foo')\n          );\n",
 				},
 				{
 					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
-					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION FOR (RANK(1))\nSET SUBPARTITION TEMPLATE\n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION a \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+				},
+				{
+					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
+					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION FOR (RANK(1)) \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
+				},
+				{
+					Schema: "foo2", Name: "foo", ObjectType: toc.OBJ_TABLE,
+					Statement: "\n\nALTER TABLE foo2.foo ALTER PARTITION a ALTER PARTITION b \nSET SUBPARTITION TEMPLATE \n          (\n          SUBPARTITION d VALUES(3) WITH (tablename='foo'),\n          DEFAULT SUBPARTITION e  WITH (tablename='foo')\n          );\n",
 				},
 				{ // ALTER TABLE ... ATTACH PARTITION statement
 					Schema: "foo2", Name: "foopart_p1", ObjectType: toc.OBJ_TABLE, ReferenceObject: "foo2.foopart",


### PR DESCRIPTION
gprestore failed to restore a table with subpartition templates
when --redirect-schema parameter is present.
gprestore lacks support for schema replacement in
ALTER TABLE ... SET SUBPARTITION TEMPLATE ... queries.

Add regex to catch and replace schema in these queries.

Add unit and e2e tests.

Ticket: GG-643